### PR TITLE
fix EZP-24083: do not save empty url

### DIFF
--- a/eZ/Publish/Core/FieldType/Url/UrlStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage.php
@@ -45,6 +45,10 @@ class UrlStorage extends GatewayBasedStorage
         $gateway = $this->getGateway( $context );
         $url = $field->value->externalData;
 
+        if (empty($url)) {
+            return false;
+        }
+
         $map = $gateway->getUrlIdMap( array( $url ) );
 
         if ( isset( $map[$url] ) )


### PR DESCRIPTION
This PR fixes https://jira.ez.no/browse/EZP-24083.

The issue is present when creating and/or updating content with empty ezurl field type.
In that case we end up with multiple entries in the database with url set to null and the same md5 hash.

Original PR by @iherak: https://github.com/ezsystems/ezpublish-kernel/pull/1337
