### PR TITLE
fix EZP-25149: Catch a yet uncaught exception in ez_image_alias - rebased

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -476,6 +476,16 @@ class ContentExtension extends Twig_Extension
                 );
             }
         }
+        catch ( InvalidArgumentException $e )
+        {
+            if ( isset( $this->logger ) )
+            {
+                $this->logger->error(
+                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because an image could not be created from the given input"
+                );
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
This PR fixes https://jira.ez.no/browse/EZP-25149 by catching an exception raised in vendor/imagine/imagine/lib/Imagine/Gd/Imagine.php when an image could not created from the input, e.g. when the source file is invalid.
