### PR TITLE
fix EZP-24123: Increase searchTresholdValue in FullText search

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/FullText.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/FullText.php
@@ -27,7 +27,7 @@ class FullText extends CriterionHandler
      * @var array
      */
     protected $configuration = array(
-        'searchThresholdValue' => 20,
+        'searchThresholdValue' => 100000,
         'enableWildcards' => true,
         'commands' => array(
             'apostrophe_normalize',


### PR DESCRIPTION
This PR addresses the problem noted in http://share.ez.no/forums/ez-publish-5-platform/fulltext-search-and-result-missing where the full text search would not return results.

It is a partial fix for https://jira.ez.no/browse/EZP-24213 suggested by @andrerom in http://share.ez.no/forums/ez-publish-5-platform/fulltext-search-and-result-missing#comment87280
