### PR TITLE
EZP-24759: Repository sudo method does not use signal slot repo

### DIFF
--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -283,12 +283,13 @@ class Repository implements RepositoryInterface
      * @access private This function is not official API atm, and can change anytime.
      *
      * @param \Closure $callback
+     * @param \eZ\Publish\API\Repository\Repository $outerRepository
      *
      * @throws \RuntimeException Thrown on recursive sudo() use.
      * @throws \Exception Re throws exceptions thrown inside $callback
      * @return mixed
      */
-    public function sudo( \Closure $callback )
+    public function sudo( \Closure $callback, RepositoryInterface $outerRepository = null )
     {
         if ( $this->sudoFlag === true )
             throw new RuntimeException( "Recursive sudo use detected, abort abort!" );
@@ -296,7 +297,7 @@ class Repository implements RepositoryInterface
         $this->sudoFlag = true;
         try
         {
-            $returnValue = $callback( $this );
+            $returnValue = $callback( $outerRepository !== null ? $outerRepository : $this );
         }
         catch ( Exception $e  )
         {

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -193,7 +193,7 @@ class Repository implements RepositoryInterface
      */
     public function sudo( \Closure $callback )
     {
-        return $this->repository->sudo( $callback );
+        return $this->repository->sudo( $callback, $this );
     }
 
     /**


### PR DESCRIPTION
When using sudo method in repository with signal slot wrapper activated, final closure call does not use the signal slot repository as a param, instead it uses core implementation.

Original PR: https://github.com/ezsystems/ezpublish-kernel/pull/1393
