### PR TITLE
Fix EZP-24982: Generating links when previewing content in siteaccess with URI matching does not work

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -24,7 +24,7 @@ services:
 
     ezpublish.content_preview_helper:
         class: %ezpublish.content_preview_helper.class%
-        arguments: [@ezpublish.api.service.content, @ezpublish.api.service.location, @event_dispatcher, @ezpublish.config.resolver]
+        arguments: [@ezpublish.api.service.content, @ezpublish.api.service.location, @event_dispatcher, @ezpublish.config.resolver, @ezpublish.siteaccess_router]
         calls:
             - [setSiteAccess, [@ezpublish.siteaccess]]
 

--- a/eZ/Publish/Core/Helper/ContentPreviewHelper.php
+++ b/eZ/Publish/Core/Helper/ContentPreviewHelper.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -46,11 +47,17 @@ class ContentPreviewHelper implements SiteAccessAware
      */
     private $configResolver;
 
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface
+     */
+    protected $siteAccessRouter;
+
     public function __construct(
         ContentService $contentService,
         LocationService $locationService,
         EventDispatcherInterface $eventDispatcher,
-        ConfigResolverInterface $configResolver
+        ConfigResolverInterface $configResolver,
+        SiteAccessRouterInterface $siteAccessRouter
     )
     {
         $this->contentService = $contentService;
@@ -58,6 +65,7 @@ class ContentPreviewHelper implements SiteAccessAware
 
         $this->eventDispatcher = $eventDispatcher;
         $this->configResolver = $configResolver;
+        $this->siteAccessRouter = $siteAccessRouter;
     }
 
     public function setSiteAccess( SiteAccess $siteAccess = null )
@@ -84,7 +92,7 @@ class ContentPreviewHelper implements SiteAccessAware
      */
     public function changeConfigScope( $siteAccessName )
     {
-        $event = new ScopeChangeEvent( new SiteAccess( $siteAccessName, 'preview' ) );
+        $event = new ScopeChangeEvent( $this->siteAccessRouter->matchByName( $siteAccessName ) );
         $this->eventDispatcher->dispatch( MVCEvents::CONFIG_SCOPE_CHANGE, $event );
 
         return $event->getSiteAccess();

--- a/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
@@ -37,6 +37,11 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
      */
     private $configResolver;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $siteAccessRouter;
+
     protected function setUp()
     {
         parent::setUp();
@@ -44,12 +49,20 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
         $this->locationService = $this->getMock( 'eZ\Publish\API\Repository\LocationService' );
         $this->eventDispatcher = $this->getMock( 'Symfony\Component\EventDispatcher\EventDispatcherInterface' );
         $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
+        $this->siteAccessRouter = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface');
     }
 
     public function testChangeConfigScope()
     {
         $newSiteAccessName = 'test';
-        $newSiteAccess = new SiteAccess( $newSiteAccessName, 'preview' );
+        $newSiteAccess = new SiteAccess( $newSiteAccessName );
+
+        $this->siteAccessRouter
+            ->expects( $this->once() )
+            ->method( 'matchByName' )
+            ->with( $this->equalTo( $newSiteAccessName ) )
+            ->willReturn( $newSiteAccess );
+
         $event = new ScopeChangeEvent( $newSiteAccess );
         $this->eventDispatcher
             ->expects( $this->once() )
@@ -61,7 +74,8 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             $this->contentService,
             $this->locationService,
             $this->eventDispatcher,
-            $this->configResolver
+            $this->configResolver,
+            $this->siteAccessRouter
         );
         $helper->setSiteAccess( $originalSiteAccess );
         $this->assertEquals(
@@ -83,7 +97,8 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             $this->contentService,
             $this->locationService,
             $this->eventDispatcher,
-            $this->configResolver
+            $this->configResolver,
+            $this->siteAccessRouter
         );
         $helper->setSiteAccess( $originalSiteAccess );
         $this->assertEquals(
@@ -118,7 +133,8 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             $this->contentService,
             $this->locationService,
             $this->eventDispatcher,
-            $this->configResolver
+            $this->configResolver,
+            $this->siteAccessRouter
         );
         $location = $helper->getPreviewLocation( $contentId );
         $this->assertInstanceOf( 'eZ\Publish\API\Repository\Values\Content\Location', $location );
@@ -153,7 +169,8 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             $this->contentService,
             $this->locationService,
             $this->eventDispatcher,
-            $this->configResolver
+            $this->configResolver,
+            $this->siteAccessRouter
         );
         $returnedLocation = $helper->getPreviewLocation( $contentId );
         $this->assertSame( $location, $returnedLocation );


### PR DESCRIPTION
> JIRA issue: https://jira.ez.no/browse/EZP-24982

When previewing content in a siteaccess which is matched with URI type matching (e.g. http://example.com/cro), generated links loose their URI part.

The siteaccess is correctly set to preview subrequest, but not the info that it's an URI type matched siteaccess, which means that URLs can't be generated correctly.

Original PR: https://github.com/ezsystems/ezpublish-kernel/pull/1474
