### PR TITLE
Use mbstring on string ops on UrlAlias

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -737,6 +737,6 @@ class Handler implements UrlAliasHandlerInterface
      */
     protected function getHash( $text )
     {
-        return md5( strtolower( $text ) );
+        return md5( mb_strtolower( $text, 'UTF-8' ) );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -934,6 +934,21 @@ class UrlAliasHandlerTest extends TestCase
         );
     }
 
+    /**
+     * Test for the lookup() method with uppercase utf8 characters.
+     *
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler::lookup
+     * @depends testLookup
+     */
+    public function testLookupUppercaseIri()
+    {
+        $handler = $this->getHandler();
+        $this->insertDatabaseFixture( __DIR__ . '/_fixtures/urlaliases_location_iri.php' );
+
+        $urlAlias = $handler->lookup( 'ŒÄ' );
+        self::assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias );
+    }
+
     protected function assertVirtualUrlAliasValid( UrlAlias $urlAlias, $id )
     {
         self::assertInstanceOf( "eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias", $urlAlias );

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/_fixtures/urlaliases_location_iri.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/_fixtures/urlaliases_location_iri.php
@@ -1,0 +1,99 @@
+<?php
+
+return array(
+    'ezurlalias_ml' => array(
+        0 => array(
+            'action' => 'eznode:2',
+            'action_type' => 'eznode',
+            'alias_redirects' => '1',
+            'id' => '1',
+            'is_alias' => '0',
+            'is_original' => '1',
+            'lang_mask' => '3',
+            'link' => '1',
+            'parent' => '0',
+            'text' => '',
+            'text_md5' => 'd41d8cd98f00b204e9800998ecf8427e',
+        ),
+        1 => array(
+            'action' => 'eznode:314',
+            'action_type' => 'eznode',
+            'alias_redirects' => '1',
+            'id' => '2',
+            'is_alias' => '0',
+            'is_original' => '1',
+            'lang_mask' => '3',
+            'link' => '2',
+            'parent' => '0',
+            'text' => 'ŒÄ',
+            'text_md5' => 'c2bc273ec708a8e4ce1a5c2cab974a6d',
+        ),
+        3 => array(
+            'action' => 'eznode:315',
+            'action_type' => 'eznode',
+            'alias_redirects' => '1',
+            'id' => '3',
+            'is_alias' => '0',
+            'is_original' => '1',
+            'lang_mask' => '6',
+            'link' => '3',
+            'parent' => '2',
+            'text' => 'dva',
+            'text_md5' => 'c67ed9a09ab136fae610b6a087d82e21',
+        ),
+        4 => array(
+            'action' => 'eznode:316',
+            'action_type' => 'eznode',
+            'alias_redirects' => '1',
+            'id' => '4',
+            'is_alias' => '0',
+            'is_original' => '1',
+            'lang_mask' => '4',
+            'link' => '4',
+            'parent' => '3',
+            'text' => 'three',
+            'text_md5' => '35d6d33467aae9a2e3dccb4b6b027878',
+        ),
+        5 => array(
+            'action' => 'eznode:316',
+            'action_type' => 'eznode',
+            'alias_redirects' => '1',
+            'id' => '4',
+            'is_alias' => '0',
+            'is_original' => '1',
+            'lang_mask' => '2',
+            'link' => '4',
+            'parent' => '3',
+            'text' => 'tri',
+            'text_md5' => 'd2cfe69af2d64330670e08efb2c86df7',
+        ),
+    ),
+    'ezcontent_language' => array(
+        0 => array(
+            'disabled' => 0,
+            'id' => 2,
+            'locale' => 'cro-HR',
+            'name' => 'Croatian (Hrvatski)'
+        ),
+        1 => array(
+            'disabled' => 0,
+            'id' => 4,
+            'locale' => 'eng-GB',
+            'name' => 'English (United Kingdom)'
+        ),
+    ),
+    'ezurlalias_ml_incr' => array(
+        0 => array(
+            'id' => '1',
+        ),
+        1 => array(
+            'id' => '2',
+        ),
+        2 => array(
+            'id' => '3',
+        ),
+        3 => array(
+            'id' => '4',
+        ),
+    ),
+);


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24737

Uses mb_strtolower() when hasing UrlAlias parts to md5.

Original PR: https://github.com/ezsystems/ezpublish-kernel/pull/1394
