### PR TITLE
Fix EZP-24215: CopyContent method returns content with 0 as its main location id

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -2707,6 +2707,11 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->assertAllFieldsEquals( $contentCopied->getFields() );
 
         $this->assertDefaultContentStates( $contentCopied->contentInfo );
+
+        $this->assertNotNull(
+            $contentCopied->contentInfo->mainLocationId,
+            'Expected main location to be set given we provided a LocationCreateStruct'
+        );
     }
 
     /**
@@ -2767,6 +2772,11 @@ class ContentServiceTest extends BaseContentServiceTest
         );
 
         $this->assertEquals( 1, $contentCopied->getVersionInfo()->versionNo );
+
+        $this->assertNotNull(
+            $contentCopied->contentInfo->mainLocationId,
+            'Expected main location to be set given we provided a LocationCreateStruct'
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -223,6 +223,8 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         $this->cache->getItem( 'location', $location->id )->set( $location );
         $this->cache->clear( 'location', 'subtree' );
         $this->cache->clear( 'content', 'locations', $location->contentId );
+        $this->cache->clear( 'content', $location->contentId );
+        $this->cache->clear( 'content', 'info', $location->contentId );
         $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', $location->contentId );
         $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', 'inherited', $location->contentId );
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -708,11 +708,23 @@ class LocationHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->at( 3 ) )
             ->method( 'clear' )
-            ->with( 'user', 'role', 'assignments', 'byGroup', 2 )
+            ->with( 'content', 2 )
             ->will( $this->returnValue( true ) );
 
         $this->cacheMock
             ->expects( $this->at( 4 ) )
+            ->method( 'clear' )
+            ->with( 'content', 'info', 2 )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 5 ) )
+            ->method( 'clear' )
+            ->with( 'user', 'role', 'assignments', 'byGroup', 2 )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 6 ) )
             ->method( 'clear' )
             ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited', 2 )
             ->will( $this->returnValue( true ) );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -252,7 +252,7 @@ class Mapper
         $contentInfo->alwaysAvailable = (int)$row["{$prefix}language_mask"] & 1;
         $contentInfo->mainLanguageCode = $this->languageHandler->load( $row["{$prefix}initial_language_id"] )->languageCode;
         $contentInfo->remoteId = $row["{$prefix}remote_id"];
-        $contentInfo->mainLocationId = $row["{$treePrefix}main_node_id"];
+        $contentInfo->mainLocationId = ( $row["{$treePrefix}main_node_id"] !== null ? (int)$row["{$treePrefix}main_node_id"] : null );
 
         return $contentInfo;
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1727,7 +1727,7 @@ class ContentService implements ContentServiceInterface
             throw $e;
         }
 
-        return $content;
+        return $this->internalLoadContent( $content->id );
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5342,7 +5342,7 @@ class ContentTest extends BaseServiceMockTest
     public function testCopyContent()
     {
         $repositoryMock = $this->getRepositoryMock();
-        $contentService = $this->getPartlyMockedContentService( array( "internalLoadContentInfo" ) );
+        $contentService = $this->getPartlyMockedContentService( array( "internalLoadContentInfo", "internalLoadContent" ) );
         $locationServiceMock = $this->getLocationServiceMock();
         $contentInfoMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo" );
         $locationCreateStruct = new LocationCreateStruct();
@@ -5417,6 +5417,13 @@ class ContentTest extends BaseServiceMockTest
                 $locationCreateStruct
             );
 
+        $contentService->expects( $this->once() )
+            ->method( "internalLoadContent" )
+            ->with(
+                $content->id
+            )
+            ->will( $this->returnValue( $content ) );
+
         /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfoMock */
         $contentService->copyContent( $contentInfoMock, $locationCreateStruct, null );
     }
@@ -5431,7 +5438,7 @@ class ContentTest extends BaseServiceMockTest
     public function testCopyContentWithVersionInfo()
     {
         $repositoryMock = $this->getRepositoryMock();
-        $contentService = $this->getPartlyMockedContentService( array( "internalLoadContentInfo" ) );
+        $contentService = $this->getPartlyMockedContentService( array( "internalLoadContentInfo", "internalLoadContent" ) );
         $locationServiceMock = $this->getLocationServiceMock();
         $contentInfoMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo" );
         $locationCreateStruct = new LocationCreateStruct();
@@ -5505,6 +5512,13 @@ class ContentTest extends BaseServiceMockTest
                 $content->getVersionInfo()->getContentInfo(),
                 $locationCreateStruct
             );
+
+        $contentService->expects( $this->once() )
+            ->method( "internalLoadContent" )
+            ->with(
+                $content->id
+            )
+            ->will( $this->returnValue( $content ) );
 
         /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfoMock */
         $contentService->copyContent( $contentInfoMock, $locationCreateStruct, $versionInfoMock );
@@ -5640,8 +5654,14 @@ class ContentTest extends BaseServiceMockTest
 
         $contentMock->expects( $this->any() )
             ->method( "__get" )
-            ->with( "contentInfo" )
-            ->will( $this->returnValue( $contentInfoMock ) );
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array( "id", 42 ),
+                        array( "contentInfo", $contentInfoMock ),
+                    )
+                )
+            );
         $contentMock->expects( $this->any() )
             ->method( "getVersionInfo" )
             ->will( $this->returnValue( $versionInfoMock ) );


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24215

The issue was discovered while using content service copyContent method.
During the copying, the content's mainLocationId is set to 0, and location service checks for null.

Steps to reproduce:

``` php
$oldLocation = $locationService->loadLocation( $locationId );
$locationCreateStruct = $locationService->newLocationCreateStruct( $newLocationParentId );
$copiedContent = $contentService->copyContent( $oldLocation->contentInfo, $locationCreateStruct );
var_dump( $contentService->loadContentInfo( $copiedContent->id ) );
```

MainLocationId is set to 0 in dumped content info

This PR proposes the fix for this.
Casting main location id to int in Content Mapper should happen only if main location id is not null, and copyContent method in Content Service should reload the content before returning it.
Also, Location Handler should invalidate SPI cache of the content and content info on create, in order for the content to get the correct information about main location.

Original PR: https://github.com/ezsystems/ezpublish-kernel/pull/1219
