### PR TITLE
Fix EZP-21797: recursive sudo usage.

### DIFF
--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -41,11 +41,11 @@ class Repository implements RepositoryInterface
     protected $currentUser;
 
     /**
-     * Flag to specify if current execution is sudo mode, only set by {@see sudo()}.
+     * Counter for the current sudo nesting level {@see sudo()}.
      *
-     * @var bool
+     * @var int
      */
-    private $sudoFlag = false;
+    private $sudoNestingLevel = 0;
 
     /**
      * Instance of content service
@@ -191,8 +191,6 @@ class Repository implements RepositoryInterface
     private $transactionCount = 0;
 
     /**
-
-    /**
      * Constructor
      *
      * Construct repository object with provided storage engine
@@ -291,21 +289,18 @@ class Repository implements RepositoryInterface
      */
     public function sudo( \Closure $callback, RepositoryInterface $outerRepository = null )
     {
-        if ( $this->sudoFlag === true )
-            throw new RuntimeException( "Recursive sudo use detected, abort abort!" );
-
-        $this->sudoFlag = true;
+        $this->sudoNestingLevel++;
         try
         {
             $returnValue = $callback( $outerRepository !== null ? $outerRepository : $this );
         }
         catch ( Exception $e  )
         {
-            $this->sudoFlag = false;
+            $this->sudoNestingLevel--;
             throw $e;
         }
 
-        $this->sudoFlag = false;
+        $this->sudoNestingLevel--;
         return $returnValue;
     }
 
@@ -322,8 +317,8 @@ class Repository implements RepositoryInterface
      */
     public function hasAccess( $module, $function, User $user = null )
     {
-        // Full access if sudoFlag is set by {@see sudo()}
-        if ( $this->sudoFlag === true )
+        // Full access if sudo nesting level is set by {@see sudo()}
+        if ( $this->sudoNestingLevel > 0 )
             return true;
 
         if ( $user === null )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21797

On certain conditions, PAPI will attempt to use sudo recursively (f.e. when using a legacy slot in sudo operation, as described in related JIRA).

This effectively removes the exception, implementing instead a "nesting level" counter instead (similar to transaction counter).

Original PR by @joaoinacio : https://github.com/ezsystems/ezpublish-kernel/pull/1083
