### PR TITLE
Fix EZP-24618: Error displaying page block if block item is unauth.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/FieldType/Page/PageService.php
+++ b/eZ/Bundle/EzPublishCoreBundle/FieldType/Page/PageService.php
@@ -26,7 +26,14 @@ class PageService extends BasePageService
         $contentInfoObjects = array();
         foreach ( $this->getValidBlockItems( $block ) as $item )
         {
-            $contentInfoObjects[] = $this->contentService->loadContentInfo( $item->contentId );
+            try
+            {
+                $contentInfoObjects[] = $this->contentService->loadContentInfo( $item->contentId );
+            }
+            catch ( UnauthorizedException $e )
+            {
+                // If unauthorized, disregard block as "valid" and continue loading other blocks.
+            }
         }
 
         return $contentInfoObjects;


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24618

When loading block items content, an unauthorized exception prevents the whole block from being displayed.

This causes the "offending" item to be ignored (not displayed).

Original PR by @joaoinacio at https://github.com/ezsystems/ezpublish-kernel/pull/1367
