### PR TITLE
Basic PHP7 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 # execute unit tests, integration test stubs and integration tests using legacy storage engine
 env:

--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,14 @@
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
         "friendsofsymfony/http-cache-bundle": "~1.2",
-        "sensio/framework-extra-bundle": "~3.0",
-        "mockery/mockery": "^0.9.4"
+        "sensio/framework-extra-bundle": "~3.0"
     },
     "require-dev": {
         "ezsystems/ezpublish-legacy": "@dev",
         "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "~4.1.3",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
+        "mockery/mockery": "dev-master",
         "symfony/assetic-bundle": "~2.3"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "~4.1.3",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
-        "mockery/mockery": "dev-master",
+        "mockery/mockery": "^0.9.4",
         "symfony/assetic-bundle": "~2.3"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,14 @@
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
         "friendsofsymfony/http-cache-bundle": "~1.2",
-        "sensio/framework-extra-bundle": "~3.0"
+        "sensio/framework-extra-bundle": "~3.0",
+        "mockery/mockery": "^0.9.4"
     },
     "require-dev": {
         "ezsystems/ezpublish-legacy": "@dev",
         "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "~4.1.3",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
-        "mockery/mockery": "dev-master",
         "symfony/assetic-bundle": "~2.3"
     },
     "replace": {

--- a/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/EzPublishLegacyExtension.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/EzPublishLegacyExtension.php
@@ -57,7 +57,7 @@ class EzPublishLegacyExtension extends Extension
         $processor = new ConfigurationProcessor( $container, 'ezpublish_legacy' );
         $processor->mapConfig(
             $config,
-            function ( array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizerInterface )
+            function ( array $scopeSettings, $currentScope, ContextualizerInterface $contextualizerInterface )
             {
                 if ( isset( $scopeSettings['templating']['view_layout'] ) )
                 {

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/SiteAccess/LegacyMapperTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/SiteAccess/LegacyMapperTest.php
@@ -16,6 +16,13 @@ use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
 
 class LegacyMapperTest extends LegacyBasedTestCase
 {
+    protected function setUp()
+    {
+        \PHPUnit_Framework_Error_Warning::$enabled = false;
+        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
+        parent::setUp();
+    }
+
     /**
      * @dataProvider siteAccessMatchProvider
      */

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\FieldType\Tests;
 
-use eZ\Publish\Core\FieldType\Float\Type as Float;
+use eZ\Publish\Core\FieldType\Float\Type as FloatType;
 use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
 use eZ\Publish\Core\FieldType\ValidationError;
 
@@ -32,7 +32,7 @@ class FloatTest extends FieldTypeTest
      */
     protected function createFieldTypeUnderTest()
     {
-        $fieldType = new Float();
+        $fieldType = new FloatType();
         $fieldType->setTransformationProcessor( $this->getTransformationProcessorMock() );
 
         return $fieldType;

--- a/eZ/Publish/Core/MVC/Legacy/Tests/KernelTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Tests/KernelTest.php
@@ -25,6 +25,10 @@ class KernelTest extends PHPUnit_Framework_TestCase
 
     public function testRunCallbackWithException()
     {
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            $this->markTestSkipped('This will not throw an error on PHP7');
+        }
+
         $this->getKernelHandlerMock()
             ->expects( $this->any() )
             ->method( 'runCallback' )

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/AuthorConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/AuthorConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Mail converter
+ * File containing the Author converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -14,17 +14,16 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use DOMDocument;
 
-class EmailAddress implements Converter
+class AuthorConverter implements Converter
 {
-    const VALIDATOR_IDENTIFIER = "EmailAddressValidator";
-
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\EmailAddress
+     * @return Author
      */
     public static function create()
     {
@@ -39,8 +38,7 @@ class EmailAddress implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataText      = $value->data;
-        $storageFieldValue->sortKeyString = $value->sortKey;
+        $storageFieldValue->dataText = $this->generateXmlString( $value->data );
     }
 
     /**
@@ -51,8 +49,7 @@ class EmailAddress implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data    = $value->dataText;
-        $fieldValue->sortKey = $value->sortKeyString;
+        $fieldValue->data = $this->restoreValueFromXmlString( $value->dataText );
     }
 
     /**
@@ -63,7 +60,7 @@ class EmailAddress implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        $storageDef->dataText1 = $fieldDef->defaultValue->data;
+        // Nothing to store
     }
 
     /**
@@ -74,10 +71,7 @@ class EmailAddress implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $validatorConstraints = array( self::VALIDATOR_IDENTIFIER => array() );
-        $fieldDef->fieldTypeConstraints->validators = $validatorConstraints;
-        $fieldDef->defaultValue->data = isset( $storageDef->dataText1 ) ? $storageDef->dataText1 : '';
-        $fieldDef->defaultValue->sortKey = $fieldDef->defaultValue->data;
+        $fieldDef->defaultValue->data = array();
     }
 
     /**
@@ -91,6 +85,63 @@ class EmailAddress implements Converter
      */
     public function getIndexColumn()
     {
-        return 'sort_key_string';
+        return false;
+    }
+
+    /**
+     * Generates XML string from $authorValue to be stored in storage engine
+     *
+     * @param array $authorValue
+     *
+     * @return string The generated XML string
+     */
+    private function generateXmlString( array $authorValue )
+    {
+        $doc = new DOMDocument( '1.0', 'utf-8' );
+
+        $root = $doc->createElement( 'ezauthor' );
+        $doc->appendChild( $root );
+
+        $authors = $doc->createElement( 'authors' );
+        $root->appendChild( $authors );
+
+        foreach ( $authorValue as $author )
+        {
+            $authorNode = $doc->createElement( 'author' );
+            $authorNode->setAttribute( 'id', $author["id"] );
+            $authorNode->setAttribute( 'name', $author["name"] );
+            $authorNode->setAttribute( 'email', $author["email"] );
+            $authors->appendChild( $authorNode );
+            unset( $authorNode );
+        }
+
+        return $doc->saveXML();
+    }
+
+    /**
+     * Restores an author Value object from $xmlString
+     *
+     * @param string $xmlString XML String stored in storage engine
+     *
+     * @return \eZ\Publish\Core\FieldType\Author\Value
+     */
+    private function restoreValueFromXmlString( $xmlString )
+    {
+        $dom = new DOMDocument( '1.0', 'utf-8' );
+        $authors = array();
+
+        if ( $dom->loadXML( $xmlString ) === true )
+        {
+            foreach ( $dom->getElementsByTagName( 'author' ) as $author )
+            {
+                $authors[] = array(
+                    'id' => $author->getAttribute( 'id' ),
+                    'name' => $author->getAttribute( 'name' ),
+                    'email' => $author->getAttribute( 'email' )
+                );
+            }
+        }
+
+        return $authors;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CheckboxConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CheckboxConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Integer converter
+ * File containing the Checkbox converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -15,19 +15,14 @@ use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class Integer implements Converter
+class CheckboxConverter implements Converter
 {
-    const FLOAT_VALIDATOR_IDENTIFIER = "IntegerValueValidator";
-
-    const HAS_MIN_VALUE = 1;
-    const HAS_MAX_VALUE = 2;
-
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Integer
+     * @return Checkbox
      */
     public static function create()
     {
@@ -42,8 +37,8 @@ class Integer implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataInt = $value->data;
-        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
+        $storageFieldValue->dataInt    = (int)$value->data;
+        $storageFieldValue->sortKeyInt = (int)$value->data;
     }
 
     /**
@@ -54,8 +49,8 @@ class Integer implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = $value->dataInt;
-        $fieldValue->sortKey = $value->sortKeyInt;
+        $fieldValue->data    = (bool)$value->dataInt;
+        $fieldValue->sortKey = $value->dataInt;
     }
 
     /**
@@ -66,19 +61,7 @@ class Integer implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        if ( isset( $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'] ) )
-        {
-            $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'];
-        }
-
-        if ( isset( $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'] ) )
-        {
-            $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'];
-        }
-
-        // Defining dataInt4 which holds the validator state (min value/max value/minMax value)
-        $storageDef->dataInt4 = $this->getStorageDefValidatorState( $storageDef->dataInt1, $storageDef->dataInt2 );
-        $storageDef->dataInt3 = $fieldDef->defaultValue->data;
+        $storageDef->dataInt3 = (int)$fieldDef->defaultValue->data;
     }
 
     /**
@@ -89,19 +72,7 @@ class Integer implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $validatorParameters = array( 'minIntegerValue' => false, 'maxIntegerValue' => false );
-        if ( $storageDef->dataInt4 & self::HAS_MIN_VALUE )
-        {
-            $validatorParameters['minIntegerValue'] = $storageDef->dataInt1;
-        }
-
-        if ( $storageDef->dataInt4 & self::HAS_MAX_VALUE )
-        {
-            $validatorParameters['maxIntegerValue'] = $storageDef->dataInt2;
-        }
-        $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER] = $validatorParameters;
-        $fieldDef->defaultValue->data = $storageDef->dataInt3;
-        $fieldDef->defaultValue->sortKey = ( $storageDef->dataInt3 === null ? 0 : $storageDef->dataInt3 );
+        $fieldDef->defaultValue->data = !empty( $storageDef->dataInt3 ) ? (bool)$storageDef->dataInt3 : false;
     }
 
     /**
@@ -118,27 +89,4 @@ class Integer implements Converter
         return 'sort_key_int';
     }
 
-    /**
-     * Returns validator state for storage definition.
-     * Validator state is a bitfield value composed of:
-     *   - {@link self::HAS_MAX_VALUE}
-     *   - {@link self::HAS_MIN_VALUE}
-     *
-     * @param int|null $minValue Minimum int value, or null if not set
-     * @param int|null $maxValue Maximum int value, or null if not set
-     *
-     * @return int
-     */
-    private function getStorageDefValidatorState( $minValue, $maxValue )
-    {
-        $state = 0;
-
-        if ( $minValue !== null )
-            $state |= self::HAS_MIN_VALUE;
-
-        if ( $maxValue !== null )
-            $state |= self::HAS_MAX_VALUE;
-
-        return $state;
-    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -21,7 +21,7 @@ use DateInterval;
 use DOMDocument;
 use SimpleXMLElement;
 
-class DateAndTime implements Converter
+class DateAndTimeConverter implements Converter
 {
     /**
      * Factory for current class

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Rating converter
+ * File containing the Date field value converter class
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -14,15 +14,21 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\Core\FieldType\Date\Type as DateType;
+use eZ\Publish\Core\FieldType\FieldSettings;
+use DateTime;
 
-class Rating implements Converter
+/**
+ * Date field value converter class
+ */
+class DateConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Rating
+     * @return \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter
      */
     public static function create()
     {
@@ -37,7 +43,8 @@ class Rating implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataInt = $value->data ? 1 : null;
+        $storageFieldValue->dataInt = ( $value->data !== null ? $value->data["timestamp"] : null );
+        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
     /**
@@ -48,7 +55,16 @@ class Rating implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = (bool)$value->dataInt;
+        if ( $value->dataInt === null || $value->dataInt == 0 )
+        {
+            return;
+        }
+
+        $fieldValue->data = array(
+            "timestamp" => $value->dataInt,
+            "rfc850" => null,
+        );
+        $fieldValue->sortKey = $value->sortKeyInt;
     }
 
     /**
@@ -59,6 +75,7 @@ class Rating implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
+        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings["defaultType"];
     }
 
     /**
@@ -69,7 +86,28 @@ class Rating implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $fieldDef->defaultValue->data = false;
+        $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
+            array(
+                "defaultType" => $storageDef->dataInt1
+            )
+        );
+
+        // Building default value
+        switch ( $fieldDef->fieldTypeConstraints->fieldSettings["defaultType"] )
+        {
+            case DateType::DEFAULT_CURRENT_DATE:
+                $dateTime = new DateTime();
+                $dateTime->setTime( 0, 0, 0 );
+                $data = array(
+                    "timestamp" => $dateTime->getTimestamp(),
+                    "rfc850" => null,
+                );
+                break;
+            default:
+                $data = null;
+        }
+
+        $fieldDef->defaultValue->data = $data;
     }
 
     /**
@@ -83,6 +121,6 @@ class Rating implements Converter
      */
     public function getIndexColumn()
     {
-        return false;
+        return "sort_key_int";
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
@@ -15,7 +15,7 @@ use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class Float implements Converter
+class FloatConverter implements Converter
 {
     const FLOAT_VALIDATOR_IDENTIFIER = "FloatValueValidator";
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -18,7 +18,7 @@ use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class Image implements Converter
+class ImageConverter implements Converter
 {
     /** @var IOServiceInterface */
     private $imageIoService;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Relation converter
+ * File containing the Integer converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -15,14 +15,19 @@ use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class Relation implements Converter
+class IntegerConverter implements Converter
 {
+    const FLOAT_VALIDATOR_IDENTIFIER = "IntegerValueValidator";
+
+    const HAS_MIN_VALUE = 1;
+    const HAS_MAX_VALUE = 2;
+
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Url
+     * @return Integer
      */
     public static function create()
     {
@@ -37,9 +42,7 @@ class Relation implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataInt = !empty( $value->data['destinationContentId'] )
-            ? $value->data['destinationContentId']
-            : null;
+        $storageFieldValue->dataInt = $value->data;
         $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
@@ -51,10 +54,8 @@ class Relation implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = array(
-            "destinationContentId" => $value->dataInt ?: null,
-        );
-        $fieldValue->sortKey = (int)$value->sortKeyInt;
+        $fieldValue->data = $value->dataInt;
+        $fieldValue->sortKey = $value->sortKeyInt;
     }
 
     /**
@@ -65,11 +66,19 @@ class Relation implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        // Selection method, 0 = browse, 1 = dropdown
-        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings['selectionMethod'];
+        if ( isset( $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'] ) )
+        {
+            $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'];
+        }
 
-        // Selection root, location ID
-        $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->fieldSettings['selectionRoot'];
+        if ( isset( $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'] ) )
+        {
+            $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'];
+        }
+
+        // Defining dataInt4 which holds the validator state (min value/max value/minMax value)
+        $storageDef->dataInt4 = $this->getStorageDefValidatorState( $storageDef->dataInt1, $storageDef->dataInt2 );
+        $storageDef->dataInt3 = $fieldDef->defaultValue->data;
     }
 
     /**
@@ -80,15 +89,19 @@ class Relation implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        // Selection method, 0 = browse, 1 = dropdown
-        $fieldDef->fieldTypeConstraints->fieldSettings['selectionMethod'] = $storageDef->dataInt1;
+        $validatorParameters = array( 'minIntegerValue' => false, 'maxIntegerValue' => false );
+        if ( $storageDef->dataInt4 & self::HAS_MIN_VALUE )
+        {
+            $validatorParameters['minIntegerValue'] = $storageDef->dataInt1;
+        }
 
-        // Selection root, location ID
-
-        $fieldDef->fieldTypeConstraints->fieldSettings['selectionRoot'] =
-            $storageDef->dataInt2 === 0
-            ? ''
-            : $storageDef->dataInt2;
+        if ( $storageDef->dataInt4 & self::HAS_MAX_VALUE )
+        {
+            $validatorParameters['maxIntegerValue'] = $storageDef->dataInt2;
+        }
+        $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER] = $validatorParameters;
+        $fieldDef->defaultValue->data = $storageDef->dataInt3;
+        $fieldDef->defaultValue->sortKey = ( $storageDef->dataInt3 === null ? 0 : $storageDef->dataInt3 );
     }
 
     /**
@@ -98,10 +111,34 @@ class Relation implements Converter
      * "sort_key_int" or "sort_key_string". This column is then used for
      * filtering and sorting for this type.
      *
-     * @return false
+     * @return string
      */
     public function getIndexColumn()
     {
         return 'sort_key_int';
+    }
+
+    /**
+     * Returns validator state for storage definition.
+     * Validator state is a bitfield value composed of:
+     *   - {@link self::HAS_MAX_VALUE}
+     *   - {@link self::HAS_MIN_VALUE}
+     *
+     * @param int|null $minValue Minimum int value, or null if not set
+     * @param int|null $maxValue Maximum int value, or null if not set
+     *
+     * @return int
+     */
+    private function getStorageDefValidatorState( $minValue, $maxValue )
+    {
+        $state = 0;
+
+        if ( $minValue !== null )
+            $state |= self::HAS_MIN_VALUE;
+
+        if ( $maxValue !== null )
+            $state |= self::HAS_MAX_VALUE;
+
+        return $state;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/KeywordConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/KeywordConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Image converter
+ * File containing the Keyword converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -12,18 +12,17 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
-use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class BinaryFile implements Converter
+class KeywordConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Image
+     * @return Keyword
      */
     public static function create()
     {
@@ -48,6 +47,7 @@ class BinaryFile implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
+        $fieldValue->data = array();
     }
 
     /**
@@ -58,9 +58,6 @@ class BinaryFile implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        $storageDef->dataInt1 = ( isset( $fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'] )
-            ? $fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize']
-            : 0 );
     }
 
     /**
@@ -71,17 +68,6 @@ class BinaryFile implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $fieldDef->fieldTypeConstraints = new FieldTypeConstraints(
-            array(
-                'validators' => array(
-                    'FileSizeValidator' => array(
-                        'maxFileSize' => ( $storageDef->dataInt1 != 0
-                            ? $storageDef->dataInt1
-                            : false ),
-                    )
-                )
-            )
-        );
     }
 
     /**
@@ -95,7 +81,7 @@ class BinaryFile implements Converter
      */
     public function getIndexColumn()
     {
-        // @todo: Correct?
-        return 'sort_key_string';
+        return false;
     }
+
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MapLocationConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MapLocationConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Selection converter
+ * File containing the MapLocation converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -9,22 +9,20 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
-use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
-use DOMDocument;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class Selection implements Converter
+class MapLocationConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Selection
+     * @return MapLocation
      */
     public static function create()
     {
@@ -39,7 +37,9 @@ class Selection implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->sortKeyString = $storageFieldValue->dataText = $value->sortKey;
+        $storageFieldValue->dataInt = isset( $value->externalData['address'] ) ? 1 : 0;
+        $storageFieldValue->dataText = '';
+        $storageFieldValue->sortKeyString = (string)$value->sortKey;
     }
 
     /**
@@ -50,18 +50,6 @@ class Selection implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        if ( $value->dataText !== '' )
-        {
-            $fieldValue->data = array_map(
-                'intval',
-                explode( '-', $value->dataText )
-            );
-        }
-        else
-        {
-            $fieldValue->data = array();
-        }
-        $fieldValue->sortKey = $value->sortKeyString;
     }
 
     /**
@@ -72,30 +60,6 @@ class Selection implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
-
-        if ( isset( $fieldSettings["isMultiple"] ) )
-            $storageDef->dataInt1 = (int)$fieldSettings["isMultiple"];
-
-        if ( !empty( $fieldSettings["options"] ) )
-        {
-            $xml = new DOMDocument( "1.0", "utf-8" );
-            $xml->appendChild(
-                $selection = $xml->createElement( "ezselection" )
-            );
-            $selection->appendChild(
-                $options = $xml->createElement( "options" )
-            );
-            foreach ( $fieldSettings["options"] as $id => $name )
-            {
-                $options->appendChild(
-                    $option = $xml->createElement( "option" )
-                );
-                $option->setAttribute( "id", $id );
-                $option->setAttribute( "name", $name );
-            }
-            $storageDef->dataText5 = $xml->saveXML();
-        }
     }
 
     /**
@@ -106,28 +70,6 @@ class Selection implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $options = array();
-        $simpleXml = simplexml_load_string( $storageDef->dataText5 );
-
-        if ( $simpleXml !== false )
-        {
-            foreach ( $simpleXml->options->option as $option )
-            {
-                $options[(int)$option["id"]] = (string)$option["name"];
-            }
-        }
-
-        $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
-            array(
-                "isMultiple" => !empty( $storageDef->dataInt1 ) ? (bool)$storageDef->dataInt1 : false,
-                "options" => $options,
-            )
-        );
-
-        // @todo: Can Selection store a default value in the DB?
-        $fieldDef->defaultValue = new FieldValue();
-        $fieldDef->defaultValue->data = array();
-        $fieldDef->defaultValue->sortKey = "";
     }
 
     /**
@@ -141,7 +83,7 @@ class Selection implements Converter
      */
     public function getIndexColumn()
     {
-        return "sort_key_string";
+        return 'sort_key_string';
     }
 
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MediaConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MediaConverter.php
@@ -14,14 +14,14 @@ use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\Core\FieldType\FieldSettings;
 
-class Media extends BinaryFile
+class MediaConverter extends BinaryFileConverter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Image
+     * @return MediaConverter
      */
     public static function create()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/NullConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/NullConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Time field value converter class
+ * File containing the Null converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -14,21 +14,18 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\FieldType\Time\Type as TimeType;
-use eZ\Publish\Core\FieldType\FieldSettings;
-use DateTime;
 
 /**
- * Time field value converter class
+ * The Null converter does not perform any conversions at all.
  */
-class Time implements Converter
+class NullConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time
+     * @return TextBlock
      */
     public static function create()
     {
@@ -43,8 +40,8 @@ class Time implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataInt = ( $value->data !== null ? $value->data : null );
-        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
+        // There is no contained data. All data is external. So we just do
+        // nothing here.
     }
 
     /**
@@ -55,13 +52,8 @@ class Time implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        if ( $value->dataInt === null )
-        {
-            return;
-        }
-
-        $fieldValue->data = $value->dataInt;
-        $fieldValue->sortKey = $value->sortKeyInt;
+        // There is no contained data. All data is external. So we just do
+        // nothing here.
     }
 
     /**
@@ -72,8 +64,8 @@ class Time implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings["defaultType"];
-        $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->fieldSettings["useSeconds"] ? 1 : 0;
+        // There is no contained data. All data is external. So we just do
+        // nothing here.
     }
 
     /**
@@ -84,25 +76,8 @@ class Time implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
-            array(
-                "defaultType" => $storageDef->dataInt1,
-                "useSeconds" => (bool)$storageDef->dataInt2
-            )
-        );
-
-        // Building default value
-        switch ( $fieldDef->fieldTypeConstraints->fieldSettings["defaultType"] )
-        {
-            case TimeType::DEFAULT_CURRENT_TIME:
-                $dateTime = new DateTime();
-                $data = $dateTime->getTimestamp() - $dateTime->setTime( 0, 0, 0 )->getTimestamp();
-                break;
-            default:
-                $data = null;
-        }
-
-        $fieldDef->defaultValue->data = $data;
+        // There is no contained data. All data is external. So we just do
+        // nothing here.
     }
 
     /**
@@ -116,6 +91,6 @@ class Time implements Converter
      */
     public function getIndexColumn()
     {
-        return "sort_key_int";
+        return false;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/PageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/PageConverter.php
@@ -18,7 +18,7 @@ use eZ\Publish\Core\FieldType\Page\Parts;
 use DOMDocument;
 use DOMElement;
 
-class Page implements Converter
+class PageConverter implements Converter
 {
     /**
      * Converts data from $value to $storageFieldValue

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RatingConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RatingConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Country converter
+ * File containing the Rating converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -11,19 +11,18 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
-use eZ\Publish\Core\FieldType\FieldSettings;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class Country implements Converter
+class RatingConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Country
+     * @return Rating
      */
     public static function create()
     {
@@ -38,8 +37,7 @@ class Country implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataText = empty( $value->data ) ? "" : implode( ",", $value->data );
-        $storageFieldValue->sortKeyString = $value->sortKey;
+        $storageFieldValue->dataInt = $value->data ? 1 : null;
     }
 
     /**
@@ -50,8 +48,7 @@ class Country implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = empty( $value->dataText ) ? null : explode( ",", $value->dataText );
-        $fieldValue->sortKey = $value->sortKeyString;
+        $fieldValue->data = (bool)$value->dataInt;
     }
 
     /**
@@ -62,14 +59,6 @@ class Country implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        if ( isset( $fieldDef->fieldTypeConstraints->fieldSettings["isMultiple"] ) )
-        {
-            $storageDef->dataInt1 = (int)$fieldDef->fieldTypeConstraints->fieldSettings["isMultiple"];
-        }
-
-        $storageDef->dataText5 = $fieldDef->defaultValue->data === null
-            ? ""
-            : implode( ",", $fieldDef->defaultValue->data );
     }
 
     /**
@@ -80,18 +69,7 @@ class Country implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
-            array(
-                "isMultiple" => !empty( $storageDef->dataInt1 ) ? (bool)$storageDef->dataInt1 : false
-            )
-        );
-
-        $fieldDef->defaultValue->data = empty( $storageDef->dataText5 )
-            ? null
-            : explode( ",", $storageDef->dataText5 );
-        // TODO This will contain comma separated country codes, which is correct for value but not for sort key.
-        // Sort key should contain comma separated lowercased country names.
-        $fieldDef->defaultValue->sortKey = $storageDef->dataText5;
+        $fieldDef->defaultValue->data = false;
     }
 
     /**
@@ -105,6 +83,6 @@ class Country implements Converter
      */
     public function getIndexColumn()
     {
-        return "sort_key_string";
+        return false;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
@@ -19,7 +19,7 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use DOMDocument;
 use PDO;
 
-class RelationList implements Converter
+class RelationListConverter implements Converter
 {
     /**
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RichTextConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RichTextConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Null converter
+ * File containing the RichText converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -14,18 +14,17 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\Core\FieldType\FieldSettings;
+use eZ\Publish\Core\FieldType\RichText\Value;
 
-/**
- * The Null converter does not perform any conversions at all.
- */
-class Null implements Converter
+class RichTextConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return TextBlock
+     * @return \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter
      */
     public static function create()
     {
@@ -40,8 +39,7 @@ class Null implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        // There is no contained data. All data is external. So we just do
-        // nothing here.
+        $storageFieldValue->dataText = $value->data;
     }
 
     /**
@@ -52,32 +50,37 @@ class Null implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        // There is no contained data. All data is external. So we just do
-        // nothing here.
+        $fieldValue->data = $value->dataText ?: Value::EMPTY_VALUE;
     }
 
     /**
-     * Converts field definition data in $fieldDef into $storageFieldDef
+     * Converts field definition data from $fieldDefinition into $storageFieldDefinition
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDefinition
      */
-    public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
+    public function toStorageFieldDefinition( FieldDefinition $fieldDefinition, StorageFieldDefinition $storageDefinition )
     {
-        // There is no contained data. All data is external. So we just do
-        // nothing here.
+        $storageDefinition->dataInt1 = $fieldDefinition->fieldTypeConstraints->fieldSettings['numRows'];
+        $storageDefinition->dataText2 = $fieldDefinition->fieldTypeConstraints->fieldSettings['tagPreset'];
     }
 
     /**
-     * Converts field definition data in $storageDef into $fieldDef
+     * Converts field definition data from $storageDefinition into $fieldDefinition
      *
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDefinition
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      */
-    public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
+    public function toFieldDefinition( StorageFieldDefinition $storageDefinition, FieldDefinition $fieldDefinition )
     {
-        // There is no contained data. All data is external. So we just do
-        // nothing here.
+        $fieldDefinition->fieldTypeConstraints->fieldSettings = new FieldSettings(
+            array(
+                'numRows' => $storageDefinition->dataInt1,
+                'tagPreset' => $storageDefinition->dataText2
+            )
+        );
+
+        $fieldDefinition->defaultValue->data = Value::EMPTY_VALUE;
     }
 
     /**
@@ -87,10 +90,11 @@ class Null implements Converter
      * "sort_key_int" or "sort_key_string". This column is then used for
      * filtering and sorting for this type.
      *
-     * @return string
+     * @return string|false
      */
     public function getIndexColumn()
     {
         return false;
     }
+
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Checkbox converter
+ * File containing the Selection converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -9,20 +9,22 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
+use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use DOMDocument;
 
-class Checkbox implements Converter
+class SelectionConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Checkbox
+     * @return Selection
      */
     public static function create()
     {
@@ -37,8 +39,7 @@ class Checkbox implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataInt    = (int)$value->data;
-        $storageFieldValue->sortKeyInt = (int)$value->data;
+        $storageFieldValue->sortKeyString = $storageFieldValue->dataText = $value->sortKey;
     }
 
     /**
@@ -49,8 +50,18 @@ class Checkbox implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data    = (bool)$value->dataInt;
-        $fieldValue->sortKey = $value->dataInt;
+        if ( $value->dataText !== '' )
+        {
+            $fieldValue->data = array_map(
+                'intval',
+                explode( '-', $value->dataText )
+            );
+        }
+        else
+        {
+            $fieldValue->data = array();
+        }
+        $fieldValue->sortKey = $value->sortKeyString;
     }
 
     /**
@@ -61,7 +72,30 @@ class Checkbox implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        $storageDef->dataInt3 = (int)$fieldDef->defaultValue->data;
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+
+        if ( isset( $fieldSettings["isMultiple"] ) )
+            $storageDef->dataInt1 = (int)$fieldSettings["isMultiple"];
+
+        if ( !empty( $fieldSettings["options"] ) )
+        {
+            $xml = new DOMDocument( "1.0", "utf-8" );
+            $xml->appendChild(
+                $selection = $xml->createElement( "ezselection" )
+            );
+            $selection->appendChild(
+                $options = $xml->createElement( "options" )
+            );
+            foreach ( $fieldSettings["options"] as $id => $name )
+            {
+                $options->appendChild(
+                    $option = $xml->createElement( "option" )
+                );
+                $option->setAttribute( "id", $id );
+                $option->setAttribute( "name", $name );
+            }
+            $storageDef->dataText5 = $xml->saveXML();
+        }
     }
 
     /**
@@ -72,7 +106,28 @@ class Checkbox implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $fieldDef->defaultValue->data = !empty( $storageDef->dataInt3 ) ? (bool)$storageDef->dataInt3 : false;
+        $options = array();
+        $simpleXml = simplexml_load_string( $storageDef->dataText5 );
+
+        if ( $simpleXml !== false )
+        {
+            foreach ( $simpleXml->options->option as $option )
+            {
+                $options[(int)$option["id"]] = (string)$option["name"];
+            }
+        }
+
+        $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
+            array(
+                "isMultiple" => !empty( $storageDef->dataInt1 ) ? (bool)$storageDef->dataInt1 : false,
+                "options" => $options,
+            )
+        );
+
+        // @todo: Can Selection store a default value in the DB?
+        $fieldDef->defaultValue = new FieldValue();
+        $fieldDef->defaultValue->data = array();
+        $fieldDef->defaultValue->sortKey = "";
     }
 
     /**
@@ -86,7 +141,7 @@ class Checkbox implements Converter
      */
     public function getIndexColumn()
     {
-        return 'sort_key_int';
+        return "sort_key_string";
     }
 
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextBlockConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextBlockConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Keyword converter
+ * File containing the TextBlock converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -14,15 +14,16 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\Core\FieldType\FieldSettings;
 
-class Keyword implements Converter
+class TextBlockConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Keyword
+     * @return TextBlock
      */
     public static function create()
     {
@@ -37,6 +38,8 @@ class Keyword implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
+        $storageFieldValue->dataText = $value->data;
+        $storageFieldValue->sortKeyString = $value->sortKey;
     }
 
     /**
@@ -47,7 +50,8 @@ class Keyword implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = array();
+        $fieldValue->data = $value->dataText;
+        $fieldValue->sortKey = $value->sortKeyString;
     }
 
     /**
@@ -58,6 +62,10 @@ class Keyword implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
+        if ( isset( $fieldDef->fieldTypeConstraints->fieldSettings["textRows"] ) )
+        {
+            $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings["textRows"];
+        }
     }
 
     /**
@@ -68,6 +76,13 @@ class Keyword implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
+        $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
+            array(
+                "textRows" => $storageDef->dataInt1
+            )
+        );
+        $fieldDef->defaultValue->data = null;
+        $fieldDef->defaultValue->sortKey = "";
     }
 
     /**
@@ -81,7 +96,6 @@ class Keyword implements Converter
      */
     public function getIndexColumn()
     {
-        return false;
+        return 'sort_key_string';
     }
-
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextLineConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextLineConverter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Url converter
+ * File containing the TextLine converter
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -15,14 +15,16 @@ use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class Url implements Converter
+class TextLineConverter implements Converter
 {
+    const STRING_LENGTH_VALIDATOR_IDENTIFIER = "StringLengthValidator";
+
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return Url
+     * @return TextLine
      */
     public static function create()
     {
@@ -37,12 +39,8 @@ class Url implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataText = isset( $value->data['text'] )
-            ? $value->data['text']
-            : null;
-        $storageFieldValue->dataInt = isset( $value->data['urlId'] )
-            ? $value->data['urlId']
-            : null;
+        $storageFieldValue->dataText = $value->data;
+        $storageFieldValue->sortKeyString = $value->sortKey;
     }
 
     /**
@@ -53,11 +51,8 @@ class Url implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = array(
-            "urlId" => $value->dataInt,
-            'text' => $value->dataText,
-        );
-        $fieldValue->sortKey = false;
+        $fieldValue->data = $value->dataText;
+        $fieldValue->sortKey = $value->sortKeyString;
     }
 
     /**
@@ -68,6 +63,25 @@ class Url implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
+        if ( isset( $fieldDef->fieldTypeConstraints->validators[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]['maxStringLength'] ) )
+        {
+            $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->validators[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]['maxStringLength'];
+        }
+        else
+        {
+            $storageDef->dataInt1 = 0;
+        }
+
+        if ( isset( $fieldDef->fieldTypeConstraints->validators[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]['minStringLength'] ) )
+        {
+            $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->validators[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]['minStringLength'];
+        }
+        else
+        {
+            $storageDef->dataInt2 = 0;
+        }
+
+        $storageDef->dataText1 = $fieldDef->defaultValue->data;
     }
 
     /**
@@ -78,9 +92,26 @@ class Url implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        // @todo: Is it possible to store a default value in the DB?
-        $fieldDef->defaultValue = new FieldValue();
-        $fieldDef->defaultValue->data = array( 'text' => null );
+        $validatorConstraints = array();
+
+        if ( isset( $storageDef->dataInt1 ) )
+        {
+            $validatorConstraints[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]["maxStringLength"] =
+                $storageDef->dataInt1 != 0 ?
+                    (int)$storageDef->dataInt1 :
+                    false;
+        }
+        if ( isset( $storageDef->dataInt2 ) )
+        {
+            $validatorConstraints[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]["minStringLength"] =
+                $storageDef->dataInt2 != 0 ?
+                    (int)$storageDef->dataInt2 :
+                    false;
+        }
+
+        $fieldDef->fieldTypeConstraints->validators = $validatorConstraints;
+        $fieldDef->defaultValue->data = $storageDef->dataText1 ?: null;
+        $fieldDef->defaultValue->sortKey = $storageDef->dataText1 ?: "";
     }
 
     /**
@@ -90,10 +121,10 @@ class Url implements Converter
      * "sort_key_int" or "sort_key_string". This column is then used for
      * filtering and sorting for this type.
      *
-     * @return false
+     * @return string
      */
     public function getIndexColumn()
     {
-        return false;
+        return 'sort_key_string';
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TimeConverter.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * File containing the ISBN converter
+ * File containing the Time field value converter class
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version 
+ * @version //autogentag//
  */
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
@@ -14,16 +14,21 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\Core\FieldType\Time\Type as TimeType;
 use eZ\Publish\Core\FieldType\FieldSettings;
+use DateTime;
 
-class ISBN implements Converter
+/**
+ * Time field value converter class
+ */
+class TimeConverter implements Converter
 {
     /**
      * Factory for current class
      *
      * @note Class should instead be configured as service if it gains dependencies.
      *
-     * @return ISBN
+     * @return \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter
      */
     public static function create()
     {
@@ -38,8 +43,8 @@ class ISBN implements Converter
      */
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataText = $value->data;
-        $storageFieldValue->sortKeyString = $value->sortKey;
+        $storageFieldValue->dataInt = ( $value->data !== null ? $value->data : null );
+        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
     /**
@@ -50,8 +55,13 @@ class ISBN implements Converter
      */
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = $value->dataText;
-        $fieldValue->sortKey = $value->sortKeyString;
+        if ( $value->dataInt === null )
+        {
+            return;
+        }
+
+        $fieldValue->data = $value->dataInt;
+        $fieldValue->sortKey = $value->sortKeyInt;
     }
 
     /**
@@ -62,16 +72,8 @@ class ISBN implements Converter
      */
     public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
     {
-        if ( isset( $fieldDef->fieldTypeConstraints->fieldSettings["isISBN13"] ) )
-        {
-            $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings["isISBN13"];
-        }
-        else
-        {
-            $storageDef->dataInt1 = 1;
-        }
-
-        $storageDef->dataText1 = $fieldDef->defaultValue->data;
+        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings["defaultType"];
+        $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->fieldSettings["useSeconds"] ? 1 : 0;
     }
 
     /**
@@ -84,12 +86,23 @@ class ISBN implements Converter
     {
         $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
             array(
-                "isISBN13" => !empty( $storageDef->dataInt1 ) ? (bool)$storageDef->dataInt1 : true
+                "defaultType" => $storageDef->dataInt1,
+                "useSeconds" => (bool)$storageDef->dataInt2
             )
         );
 
-        $fieldDef->defaultValue->data = $storageDef->dataText1 ?: null;
-        $fieldDef->defaultValue->sortKey = $storageDef->dataText1 ?: "";
+        // Building default value
+        switch ( $fieldDef->fieldTypeConstraints->fieldSettings["defaultType"] )
+        {
+            case TimeType::DEFAULT_CURRENT_TIME:
+                $dateTime = new DateTime();
+                $data = $dateTime->getTimestamp() - $dateTime->setTime( 0, 0, 0 )->getTimestamp();
+                break;
+            default:
+                $data = null;
+        }
+
+        $fieldDef->defaultValue->data = $data;
     }
 
     /**
@@ -103,6 +116,6 @@ class ISBN implements Converter
      */
     public function getIndexColumn()
     {
-        return 'sort_key_string';
+        return "sort_key_int";
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/XmlTextConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/XmlTextConverter.php
@@ -18,7 +18,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\Core\FieldType\XmlText\Value;
 use DOMDocument;
 
-class XmlText implements Converter
+class XmlTextConverter implements Converter
 {
     /**
      * Factory for current class

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Handler.php
@@ -252,16 +252,19 @@ class Handler implements BaseObjectStateHandler
     public function setPriority( $stateId, $priority )
     {
         $objectState = $this->load( $stateId );
-        $groupStates = $this->loadObjectStates( $objectState->groupId );
+        $groupObjectStates = $this->loadObjectStates( $objectState->groupId );
 
         $priorityList = array();
-        foreach ( $groupStates as $index => $groupState )
+        foreach ( $groupObjectStates as $index => $groupObjectState )
         {
-            $priorityList[$groupState->id] = $index;
+            // Update given state and push all other states with same or higher priority down
+            if ( $objectState->id === $groupObjectState->id )
+                $priorityList[$groupObjectState->id] = (int)$priority;
+            else
+                $priorityList[$groupObjectState->id] = ($index < $priority ? $index : $index + 1);
         }
 
-        $priorityList[$objectState->id] = (int)$priority;
-        asort( $priorityList );
+        asort( $priorityList, SORT_NUMERIC );
 
         foreach ( array_keys( $priorityList ) as $objectStatePriority => $objectStateId )
         {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/AuthorTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/AuthorTest.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Author as AuthorConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\AuthorConverter;
 use PHPUnit_Framework_TestCase;
 use DOMDocument;
 
@@ -24,7 +24,7 @@ use DOMDocument;
 class AuthorTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Author
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\AuthorConverter
      */
     protected $converter;
 
@@ -51,7 +51,7 @@ class AuthorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Author::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\AuthorConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -87,7 +87,7 @@ class AuthorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Author::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\AuthorConverter::toFieldValue
      */
     public function testToFieldValue()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CheckboxTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CheckboxTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Checkbox as CheckboxConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use PHPUnit_Framework_TestCase;
 
@@ -22,7 +22,7 @@ use PHPUnit_Framework_TestCase;
 class CheckboxTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Checkbox
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter
      */
     protected $converter;
 
@@ -35,7 +35,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group ezboolean
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Checkbox::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -53,7 +53,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group ezboolean
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Checkbox::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -71,7 +71,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group ezboolean
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Checkbox::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinition()
     {
@@ -95,7 +95,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group ezboolean
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Checkbox::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter::toFieldDefinition
      */
     public function testToFieldDefinition()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CountryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CountryTest.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country as CountryConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
 class CountryTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter
      */
     protected $converter;
 
@@ -46,7 +46,7 @@ class CountryTest extends PHPUnit_Framework_TestCase
      * @group fieldType
      * @group country
      * @dataProvider providerForTestToStorageValue
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter::toStorageValue
      */
     public function testToStorageValue( $data, $sortKey, $dataText, $sortKeyString )
     {
@@ -72,7 +72,7 @@ class CountryTest extends PHPUnit_Framework_TestCase
      * @group fieldType
      * @group country
      * @dataProvider providerForTestToFieldValue
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter::toFieldValue
      */
     public function testToFieldValue( $dataText, $sortKeyString, $data )
     {
@@ -88,7 +88,7 @@ class CountryTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group country
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionMultiple()
     {
@@ -124,7 +124,7 @@ class CountryTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group country
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionSingle()
     {
@@ -156,7 +156,7 @@ class CountryTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group country
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter::toFieldDefinition
      */
     public function testToFieldDefinitionMultiple()
     {
@@ -184,7 +184,7 @@ class CountryTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group country
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter::toFieldDefinition
      */
     public function testToFieldDefinitionSingle()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime as DateAndTimeConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -30,7 +30,7 @@ use ReflectionObject;
 class DateAndTimeTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter
      */
     protected $converter;
 
@@ -49,7 +49,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -70,7 +70,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -95,7 +95,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionWithAdjustment()
     {
@@ -138,7 +138,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionNoDefault()
     {
@@ -172,7 +172,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionCurrentDate()
     {
@@ -223,7 +223,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toFieldDefinition
      */
     public function testToFieldDefinitionNoDefault()
     {
@@ -242,7 +242,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toFieldDefinition
      */
     public function testToFieldDefinitionCurrentDate()
     {
@@ -265,7 +265,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toFieldDefinition
      */
     public function testToFieldDefinitionWithAdjustmentAndSeconds()
     {
@@ -295,7 +295,7 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::toFieldDefinition
      */
     public function testToFieldDefinitionWithAdjustmentNoSeconds()
     {
@@ -350,7 +350,7 @@ EOT;
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::getDateIntervalFromXML
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::getDateIntervalFromXML
      */
     public function testGetDateIntervalFromXML()
     {
@@ -369,7 +369,7 @@ EOT;
     /**
      * @group fieldType
      * @group dateTime
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime::generateDateIntervalXML
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter::generateDateIntervalXML
      */
     public function testGenerateDateIntervalXML()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date as DateConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -29,7 +29,7 @@ use DateTime;
 class DateTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter
      */
     protected $converter;
 
@@ -46,7 +46,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -65,7 +65,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -88,7 +88,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionDefaultEmpty()
     {
@@ -113,7 +113,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionDefaultCurrentDate()
     {
@@ -138,7 +138,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter::toFieldDefinition
      */
     public function testToFieldDefinitionDefaultEmpty()
     {
@@ -154,7 +154,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter::toFieldDefinition
      */
     public function testToFieldDefinitionDefaultCurrentDate()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/KeywordTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/KeywordTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Keyword as KeywordConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use PHPUnit_Framework_TestCase;
 
@@ -22,7 +22,7 @@ use PHPUnit_Framework_TestCase;
 class KeywordTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Keyword
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter
      */
     protected $converter;
 
@@ -35,7 +35,7 @@ class KeywordTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group keyword
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Keyword::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -55,7 +55,7 @@ class KeywordTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group keyword
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Keyword::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -70,7 +70,7 @@ class KeywordTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group keyword
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Keyword::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinition()
     {
@@ -80,7 +80,7 @@ class KeywordTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group keyword
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Keyword::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter::toFieldDefinition
      */
     public function testToFieldDefinition()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/MediaTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/MediaTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 use eZ\Publish\Core\FieldType\Media\Type as MediaType;
 use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Media as MediaTypeConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\MediaConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -26,13 +26,13 @@ class MediaTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->converter = MediaTypeConverter::create();
+        $this->converter = MediaConverter::create();
     }
 
     /**
      * @group fieldType
      * @group ezmedia
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Media::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\MediaConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinition()
     {
@@ -71,7 +71,7 @@ class MediaTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group ezmedia
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Media::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\MediaConverter::toFieldDefinition
      */
     public function testToFieldDefinition()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/PageTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/PageTest.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Page as PageConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\PageConverter;
 use eZ\Publish\Core\FieldType\Page\Parts;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
@@ -75,7 +75,7 @@ EOT;
     private $pageReference;
 
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Page
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\PageConverter
      */
     private $converter;
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RatingTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RatingTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating as RatingConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use PHPUnit_Framework_TestCase;
 
@@ -22,7 +22,7 @@ use PHPUnit_Framework_TestCase;
 class RatingTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter
      */
     protected $converter;
 
@@ -35,7 +35,7 @@ class RatingTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group rating
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -51,7 +51,7 @@ class RatingTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group rating
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter::toStorageValue
      */
     public function testToStorageValueDisabled()
     {
@@ -67,7 +67,7 @@ class RatingTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group rating
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -82,7 +82,7 @@ class RatingTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group rating
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter::toFieldValue
      */
     public function testToFieldValueDisabled()
     {
@@ -97,7 +97,7 @@ class RatingTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group rating
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinition()
     {
@@ -107,7 +107,7 @@ class RatingTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group rating
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter::toFieldDefinition
      */
     public function testToFieldDefinition()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
@@ -23,7 +23,7 @@ use PHPUnit_Framework_TestCase;
 class RelationListTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationListConverter
      */
     protected $converter;
 
@@ -31,7 +31,7 @@ class RelationListTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->converter = $this
-            ->getMockBuilder( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\RelationList" )
+            ->getMockBuilder( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\RelationListConverter" )
             ->disableOriginalConstructor()
             ->setMethods( array( "getRelationXmlHashFromDB" ) )
             ->getMock();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextTest.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichText as RichTextConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -23,7 +23,7 @@ use PHPUnit_Framework_TestCase;
 class RichTextTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichText
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter
      */
     protected $converter;
 
@@ -53,7 +53,7 @@ EOT;
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichText::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -66,7 +66,7 @@ EOT;
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichText::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter::toFieldValue
      */
     public function testToFieldValue()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection as SelectionConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
 class SelectionTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter
      */
     protected $converter;
 
@@ -37,7 +37,7 @@ class SelectionTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -62,7 +62,7 @@ class SelectionTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toStorageValue
      */
     public function testToStorageValueEmpty()
     {
@@ -87,7 +87,7 @@ class SelectionTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -112,7 +112,7 @@ class SelectionTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toFieldValue
      */
     public function testToFieldValueEmpty()
     {
@@ -137,7 +137,7 @@ class SelectionTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionMultiple()
     {
@@ -178,7 +178,7 @@ EOT;
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionSingle()
     {
@@ -217,7 +217,7 @@ EOT;
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toFieldDefinition
      */
     public function testToFieldDefinitionMultiple()
     {
@@ -269,7 +269,7 @@ EOT;
     /**
      * @group fieldType
      * @group selection
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter::toFieldDefinition
      */
     public function testToFieldDefinitionSingleEmpty()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextBlockTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextBlockTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlock as TextBlockConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
 class TextBlockTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlock
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter
      */
     protected $converter;
 
@@ -48,7 +48,7 @@ EOT;
     /**
      * @group fieldType
      * @group textBlock
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlock::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -66,7 +66,7 @@ EOT;
     /**
      * @group fieldType
      * @group textBlock
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlock::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -83,7 +83,7 @@ EOT;
     /**
      * @group fieldType
      * @group textBlock
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlock::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinition()
     {
@@ -111,7 +111,7 @@ EOT;
     /**
      * @group fieldType
      * @group textBlock
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlock::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter::toFieldDefinition
      */
     public function testToFieldDefinition()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextLineTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextLineTest.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine as TextLineConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
 class TextLineTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter
      */
     protected $converter;
 
@@ -37,7 +37,7 @@ class TextLineTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group textLine
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -55,7 +55,7 @@ class TextLineTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group textLine
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -73,7 +73,7 @@ class TextLineTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group textLine
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionWithValidator()
     {
@@ -111,7 +111,7 @@ class TextLineTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group textLine
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionNoValidator()
     {
@@ -141,7 +141,7 @@ class TextLineTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group textLine
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter::toFieldDefinition
      */
     public function testToFieldDefinition()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TimeTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TimeTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time as TimeConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use PHPUnit_Framework_TestCase;
@@ -29,7 +29,7 @@ use DateTime;
 class TimeTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter
      */
     protected $converter;
 
@@ -46,7 +46,7 @@ class TimeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -62,7 +62,7 @@ class TimeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -79,7 +79,7 @@ class TimeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionDefaultEmpty()
     {
@@ -103,7 +103,7 @@ class TimeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinitionDefaultCurrentTime()
     {
@@ -127,7 +127,7 @@ class TimeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter::toFieldDefinition
      */
     public function testToFieldDefinitionDefaultEmpty()
     {
@@ -153,7 +153,7 @@ class TimeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter::toFieldDefinition
      */
     public function testToFieldDefinitionDefaultCurrentTime()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/UrlTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/UrlTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url as UrlConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use PHPUnit_Framework_TestCase;
 
@@ -22,7 +22,7 @@ use PHPUnit_Framework_TestCase;
 class UrlTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter
      */
     protected $converter;
 
@@ -35,7 +35,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group url
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -53,7 +53,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group url
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -76,7 +76,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group url
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url::toStorageFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter::toStorageFieldDefinition
      */
     public function testToStorageFieldDefinition()
     {
@@ -86,7 +86,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
     /**
      * @group fieldType
      * @group url
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url::toFieldDefinition
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter::toFieldDefinition
      */
     public function testToFieldDefinition()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/XmlTextTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/XmlTextTest.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlText as XmlTextConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter;
 use PHPUnit_Framework_TestCase;
 use DOMDocument;
 
@@ -24,7 +24,7 @@ use DOMDocument;
 class XmlTextTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlText
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter
      */
     protected $converter;
 
@@ -51,7 +51,7 @@ EOT;
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlText::toStorageValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -65,7 +65,7 @@ EOT;
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlText::toFieldValue
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter::toFieldValue
      */
     public function testToFieldValue()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerTest.php
@@ -23,10 +23,10 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHa
 use eZ\Publish\Core\Persistence\Legacy\Content\Search\Location\Gateway\SortClauseHandler as LocationSortClauseHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\SortClauseHandler as CommonSortClauseHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Integer;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\IntegerConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter;
 
 /**
  * Test case for LocationSearchHandler
@@ -135,11 +135,11 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
                             $this->getDatabaseHandler(),
                             new ConverterRegistry(
                                 array(
-                                    'ezdatetime' => new DateAndTime(),
-                                    'ezinteger' => new Integer(),
-                                    'ezstring' => new TextLine(),
-                                    'ezprice' => new Integer(),
-                                    'ezurl' => new Url()
+                                    'ezdatetime' => new DateAndTimeConverter(),
+                                    'ezinteger' => new IntegerConverter(),
+                                    'ezstring' => new TextLineConverter(),
+                                    'ezprice' => new IntegerConverter(),
+                                    'ezurl' => new UrlConverter()
                                 )
                             ),
                             new CommonCriterionHandler\FieldValue\Converter(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
@@ -518,12 +518,13 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
                 $this->returnValue(
                     array(
                         new ObjectState( array( 'id' => 1, 'groupId' => 2 ) ),
-                        new ObjectState( array( 'id' => 2, 'groupId' => 2 ) )
+                        new ObjectState( array( 'id' => 2, 'groupId' => 2 ) ),
+                        new ObjectState( array( 'id' => 3, 'groupId' => 2 ) )
                     )
                 )
             );
 
-        $gatewayMock->expects( $this->exactly( 2 ) )
+        $gatewayMock->expects( $this->exactly( 3 ) )
             ->method( 'updateObjectStatePriority' );
 
         $gatewayMock->expects( $this->at( 2 ) )
@@ -533,6 +534,10 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $gatewayMock->expects( $this->at( 3 ) )
             ->method( 'updateObjectStatePriority' )
             ->with( $this->equalTo( 1 ), $this->equalTo( 1 ) );
+
+        $gatewayMock->expects( $this->at( 4 ) )
+            ->method( 'updateObjectStatePriority' )
+            ->with( $this->equalTo( 3 ), $this->equalTo( 2 ) );
 
         $handler->setPriority( 2, 0 );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerSortTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerSortTest.php
@@ -99,6 +99,42 @@ class SearchHandlerSortTest extends LanguageAwareTestCase
         );
     }
 
+    protected $contentTypeHandler;
+
+    protected function getContentTypeHandler()
+    {
+        if ( !isset( $this->contentTypeHandler ) )
+        {
+            $this->contentTypeHandler = new ContentTypeHandler(
+                new ContentTypeGateway(
+                    $this->getDatabaseHandler(),
+                    $this->getLanguageMaskGenerator()
+                ),
+                new ContentTypeMapper(
+                    new ConverterRegistry(
+                        array(
+                            'ezdatetime' => new Converter\DateAndTimeConverter(),
+                            'ezinteger' => new Converter\IntegerConverter(),
+                            'ezstring' => new Converter\TextLineConverter(),
+                            'ezprice' => new Converter\IntegerConverter(),
+                            'ezurl' => new Converter\UrlConverter(),
+                            'ezxmltext' => new Converter\XmlTextConverter(),
+                            'ezboolean' => new Converter\CheckboxConverter(),
+                            'ezkeyword' => new Converter\KeywordConverter(),
+                            'ezauthor' => new Converter\AuthorConverter(),
+                            'ezimage' => new Converter\NullConverter(),
+                            'ezsrrating' => new Converter\NullConverter(),
+                            'ezmultioption' => new Converter\NullConverter(),
+                        )
+                    )
+                ),
+                $this->getMock( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler" )
+            );
+        }
+
+        return $this->contentTypeHandler;
+    }
+
     /**
      * Returns a content mapper mock
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
@@ -19,10 +19,10 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Integer;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\IntegerConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter;
 
 /**
  * Test case for ContentSearchHandler
@@ -176,11 +176,11 @@ class SearchHandlerTest extends LanguageAwareTestCase
                             $this->getDatabaseHandler(),
                             $this->fieldRegistry = new ConverterRegistry(
                                 array(
-                                    'ezdatetime' => new DateAndTime(),
-                                    'ezinteger' => new Integer(),
-                                    'ezstring' => new TextLine(),
-                                    'ezprice' => new Integer(),
-                                    'ezurl' => new Url()
+                                    'ezdatetime' => new DateAndTimeConverter(),
+                                    'ezinteger' => new IntegerConverter(),
+                                    'ezstring' => new TextLineConverter(),
+                                    'ezprice' => new IntegerConverter(),
+                                    'ezurl' => new UrlConverter()
                                 )
                             ),
                             new Content\Search\Common\Gateway\CriterionHandler\FieldValue\Converter(

--- a/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
@@ -1,33 +1,33 @@
 parameters:
     ezpublish.persistence.legacy.field_value_converter.registry.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
 
-    ezpublish.fieldType.ezauthor.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Author
-    ezpublish.fieldType.ezbinaryfile.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\BinaryFile
-    ezpublish.fieldType.ezboolean.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Checkbox
-    ezpublish.fieldType.ezcountry.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Country
-    ezpublish.fieldType.ezdatetime.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime
-    ezpublish.fieldType.ezdate.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Date
-    ezpublish.fieldType.eztime.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Time
-    ezpublish.fieldType.ezemail.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\EmailAddress
-    ezpublish.fieldType.ezfloat.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Float
-    ezpublish.fieldType.ezgmaplocation.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\MapLocation
-    ezpublish.fieldType.ezinteger.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Integer
-    ezpublish.fieldType.ezimage.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Image
-    ezpublish.fieldType.ezisbn.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ISBN
-    ezpublish.fieldType.ezkeyword.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Keyword
-    ezpublish.fieldType.ezmedia.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Media
-    ezpublish.fieldType.ezobjectrelation.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Relation
-    ezpublish.fieldType.ezobjectrelationlist.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationList
-    ezpublish.fieldType.ezselection.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection
-    ezpublish.fieldType.ezstring.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine
-    ezpublish.fieldType.eztext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlock
-    ezpublish.fieldType.ezrichtext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichText
-    ezpublish.fieldType.ezxmltext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlText
-    ezpublish.fieldType.ezsrrating.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Rating
-    ezpublish.fieldType.ezurl.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url
-    ezpublish.fieldType.ezuser.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null
-    ezpublish.fieldType.ezpage.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Page
-    ezpublish.fieldType.eznull.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null
+    ezpublish.fieldType.ezauthor.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\AuthorConverter
+    ezpublish.fieldType.ezbinaryfile.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\BinaryFileConverter
+    ezpublish.fieldType.ezboolean.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter
+    ezpublish.fieldType.ezcountry.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter
+    ezpublish.fieldType.ezdatetime.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter
+    ezpublish.fieldType.ezdate.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter
+    ezpublish.fieldType.eztime.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter
+    ezpublish.fieldType.ezemail.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\EmailAddressConverter
+    ezpublish.fieldType.ezfloat.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\FloatConverter
+    ezpublish.fieldType.ezgmaplocation.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\MapLocationConverter
+    ezpublish.fieldType.ezinteger.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\IntegerConverter
+    ezpublish.fieldType.ezimage.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter
+    ezpublish.fieldType.ezisbn.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ISBNConverter
+    ezpublish.fieldType.ezkeyword.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter
+    ezpublish.fieldType.ezmedia.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\MediaConverter
+    ezpublish.fieldType.ezobjectrelation.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationConverter
+    ezpublish.fieldType.ezobjectrelationlist.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationListConverter
+    ezpublish.fieldType.ezselection.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter
+    ezpublish.fieldType.ezstring.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter
+    ezpublish.fieldType.eztext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter
+    ezpublish.fieldType.ezrichtext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter
+    ezpublish.fieldType.ezxmltext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter
+    ezpublish.fieldType.ezsrrating.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter
+    ezpublish.fieldType.ezurl.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter
+    ezpublish.fieldType.ezuser.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
+    ezpublish.fieldType.ezpage.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\PageConverter
+    ezpublish.fieldType.eznull.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
 
 services:
     # Note: converter services tagged with 'ezpublish.storageEngine.legacy.converter' are

--- a/eZ/Publish/SPI/Tests/FieldType/AuthorIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/AuthorIntegrationTest.php
@@ -58,7 +58,7 @@ class AuthorIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezauthor',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Author(),
+            new Legacy\Content\FieldValue\Converter\AuthorConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -626,7 +626,7 @@ abstract class BaseIntegrationTest extends TestCase
 
         $textLineFieldType = new \eZ\Publish\Core\FieldType\TextLine\Type();
         $textLineFieldType->setTransformationProcessor( $this->getTransformationProcessor() );
-        $textLineFieldValueConverter = new Legacy\Content\FieldValue\Converter\TextLine();
+        $textLineFieldValueConverter = new Legacy\Content\FieldValue\Converter\TextLineConverter();
 
         $fieldTypeRegistry->register( "ezstring", $textLineFieldType );
         $converterRegistry->register( "ezstring", $textLineFieldValueConverter );

--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -75,7 +75,7 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
         return $this->getHandler(
             'ezbinaryfile',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\BinaryFile(),
+            new Legacy\Content\FieldValue\Converter\BinaryFileConverter(),
             new FieldType\BinaryFile\BinaryFileStorage(
                 array(
                     'LegacyStorage' => new FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage(),

--- a/eZ/Publish/SPI/Tests/FieldType/CheckboxIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/CheckboxIntegrationTest.php
@@ -58,7 +58,7 @@ class CheckboxIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezboolean',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Checkbox(),
+            new Legacy\Content\FieldValue\Converter\CheckboxConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/CountryIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/CountryIntegrationTest.php
@@ -73,7 +73,7 @@ class CountryIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezcountry',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Country(),
+            new Legacy\Content\FieldValue\Converter\CountryConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/DateAndTimeIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/DateAndTimeIntegrationTest.php
@@ -58,7 +58,7 @@ class DateAndTimeIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezdatetime',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\DateAndTime(),
+            new Legacy\Content\FieldValue\Converter\DateAndTimeConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/DateIntegrationTest.php
@@ -58,7 +58,7 @@ class DateIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezdate',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Date(),
+            new Legacy\Content\FieldValue\Converter\DateConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/EmailAddressIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/EmailAddressIntegrationTest.php
@@ -58,7 +58,7 @@ class EmailAddressIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezemail',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\EmailAddress(),
+            new Legacy\Content\FieldValue\Converter\EmailAddressConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FloatIntegrationTest.php
@@ -58,7 +58,7 @@ class FloatIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezfloat',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Float(),
+            new Legacy\Content\FieldValue\Converter\FloatConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/ISBNIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ISBNIntegrationTest.php
@@ -59,7 +59,7 @@ class ISBNIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezisbn',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\ISBN(),
+            new Legacy\Content\FieldValue\Converter\ISBNConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -83,7 +83,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
         return $this->getHandler(
             'ezimage',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Image( $this->ioService, $urlRedecorator ),
+            new Legacy\Content\FieldValue\Converter\ImageConverter( $this->ioService, $urlRedecorator ),
             new FieldType\Image\ImageStorage(
                 array(
                     'LegacyStorage' => new FieldType\Image\ImageStorage\Gateway\LegacyStorage( $urlRedecorator ),

--- a/eZ/Publish/SPI/Tests/FieldType/IntegerIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/IntegerIntegrationTest.php
@@ -58,7 +58,7 @@ class IntegerIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezinteger',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Integer(),
+            new Legacy\Content\FieldValue\Converter\IntegerConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
@@ -59,7 +59,7 @@ class KeywordIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezkeyword',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Keyword(),
+            new Legacy\Content\FieldValue\Converter\KeywordConverter(),
             new FieldType\Keyword\KeywordStorage(
                 array(
                     'LegacyStorage' => new FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage(),

--- a/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
@@ -59,7 +59,7 @@ class MapLocationIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezgmaplocation',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\MapLocation(),
+            new Legacy\Content\FieldValue\Converter\MapLocationConverter(),
             new FieldType\MapLocation\MapLocationStorage(
                 array(
                     'LegacyStorage' => new FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage(),

--- a/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
@@ -74,7 +74,7 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
         return $this->getHandler(
             'ezmedia',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Media(),
+            new Legacy\Content\FieldValue\Converter\MediaConverter(),
             new FieldType\Media\MediaStorage(
                 array(
                     'LegacyStorage' => new FieldType\Media\MediaStorage\Gateway\LegacyStorage(),

--- a/eZ/Publish/SPI/Tests/FieldType/RatingIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RatingIntegrationTest.php
@@ -58,7 +58,7 @@ class RatingIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezsrrating',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Rating(),
+            new Legacy\Content\FieldValue\Converter\RatingConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/RelationIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RelationIntegrationTest.php
@@ -59,7 +59,7 @@ class RelationIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezobjectrelation',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Relation(),
+            new Legacy\Content\FieldValue\Converter\RelationConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
@@ -59,7 +59,7 @@ class RelationListIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezobjectrelationlist',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\RelationList( $this->handler ),
+            new Legacy\Content\FieldValue\Converter\RelationListConverter( $this->handler ),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\SPI\Tests\FieldType;
 
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichText as RichTextConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter;
 use eZ\Publish\Core\FieldType;
 use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;

--- a/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
@@ -44,7 +44,7 @@ class SelectionIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezselection',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Selection(),
+            new Legacy\Content\FieldValue\Converter\SelectionConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/TextBlockIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/TextBlockIntegrationTest.php
@@ -58,7 +58,7 @@ class TextBlockIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'eztext',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\TextBlock(),
+            new Legacy\Content\FieldValue\Converter\TextBlockConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/TextLineIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/TextLineIntegrationTest.php
@@ -58,7 +58,7 @@ class TextLineIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezstring',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\TextLine(),
+            new Legacy\Content\FieldValue\Converter\TextLineConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/TimeIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/TimeIntegrationTest.php
@@ -58,7 +58,7 @@ class TimeIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'eztime',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Time(),
+            new Legacy\Content\FieldValue\Converter\TimeConverter(),
             new FieldType\NullStorage()
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
@@ -59,7 +59,7 @@ class UrlIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezurl',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Url(),
+            new Legacy\Content\FieldValue\Converter\UrlConverter(),
             new FieldType\Url\UrlStorage(
                 array(
                     'LegacyStorage' => new FieldType\Url\UrlStorage\Gateway\LegacyStorage(),

--- a/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
@@ -61,7 +61,7 @@ class UserIntegrationTest extends BaseIntegrationTest
         return $this->getHandler(
             'ezuser',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\Null(),
+            new Legacy\Content\FieldValue\Converter\NullConverter(),
             new FieldType\User\UserStorage(
                 array(
                     'LegacyStorage' => new FieldType\User\UserStorage\Gateway\LegacyStorage(),

--- a/eZ/Publish/SPI/Tests/FieldType/XmlTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/XmlTextIntegrationTest.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\SPI\Tests\FieldType;
 
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlText as XmlTextConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter;
 use eZ\Publish\Core\FieldType;
 use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;


### PR DESCRIPTION
Fix issues for PHP 7.0

Changes:
- Renamed all legacy converters consistently as they had unsafe names like Float, Integer and Null
- Fix use of class aliases that used the protected keywords
- Fixed an issue in regards to legacy storage engine doing sorting on object states when setting priority in a way was wrong
- Allows some specific tests to be skipped in PHP 7

Original PR: https://github.com/ezsystems/ezpublish-kernel/pull/1285
