### PR TITLE
EZP-23847: Add Role API parameter to get inherited RoleAssignments

### DIFF
--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -222,18 +222,23 @@ interface RoleService
     public function getRoleAssignments( Role $role );
 
     /**
-     * Returns the roles assigned to the given user
+     * Returns UserRoleAssignments assigned to the given User
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user
+     * If second parameter \$inherited is true then UserGroupRoleAssignment is also returned for UserGroups User is
+     * placed in as well as those inherited from parent UserGroups.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the current user is not allowed to read a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException On invalid User object
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param boolean $inherited Also return all inherited Roles from UserGroups User belongs to, and it's parents.
      *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
+     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]|\eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment[]
      */
-    public function getRoleAssignmentsForUser( User $user );
+    public function getRoleAssignmentsForUser( User $user, $inherited = false );
 
     /**
-     * Returns the roles assigned to the given user group
+     * Returns the UserGroupRoleAssignments assigned to the given UserGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
      *

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -604,15 +604,9 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * Returns the roles assigned to the given user
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
+     * @see \eZ\Publish\API\Repository\RoleService::getRoleAssignmentsForUser()
      */
-    public function getRoleAssignmentsForUser( User $user )
+    public function getRoleAssignmentsForUser( User $user, $inherited = false )
     {
         $response = $this->client->request(
             'GET',

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -783,15 +783,7 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Returns the roles assigned to the given user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param boolean $inherited
-     *
-     * @throws \eZ\Publish\Core\Base\Exceptions\UnauthorizedException If the current user is not allowed to read a role
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue On invalid User object
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
+     * @see \eZ\Publish\API\Repository\RoleService::getRoleAssignmentsForUser()
      */
     public function getRoleAssignmentsForUser( User $user, $inherited = false )
     {

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -404,17 +404,11 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Returns the roles assigned to the given user
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
+     * @see \eZ\Publish\API\Repository\RoleService::getRoleAssignmentsForUser()
      */
-    public function getRoleAssignmentsForUser( User $user )
+    public function getRoleAssignmentsForUser( User $user, $inherited = false )
     {
-        return $this->service->getRoleAssignmentsForUser( $user );
+        return $this->service->getRoleAssignmentsForUser( $user, $inherited );
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
@@ -221,7 +221,7 @@ class RoleServiceTest extends ServiceTest
             ),
             array(
                 'getRoleAssignmentsForUser',
-                array( $user ),
+                array( $user, true ),
                 array( $roleAssignement ),
                 0
             ),


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23847

Role ID user hash context provider uses `inherited` param when calculating user hash (https://github.com/netgen/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/Security/User/ContextProvider/RoleContextProvider.php#L39), however, this param never existed in 2014.11 in signal slot repo wrapper. Because of this, inherited role assignments were never included in user hash generation process, which meant that for example anonymous and admin (and most of the users, for what it's worth) always had the same user hash (neither of them have any role assignments directly applied on them) when signal slot repo is used.

Original PR: https://github.com/ezsystems/ezpublish-kernel/pull/1056
