### PR TITLE
EZP-25533: Temporary limit FOS HTTP Cache bundle to <= 1.3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/doctrine-bundle": "1.3.*@beta",
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
-        "friendsofsymfony/http-cache-bundle": "~1.2",
+        "friendsofsymfony/http-cache-bundle": ">=1.2, <=1.3.6",
         "sensio/framework-extra-bundle": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is a temporary solution until https://github.com/ezsystems/ezpublish-kernel/pull/1601 is implemented, together with linked PR on HTTP Cache Bundle.

This limits FOS HTTP Cache bundle to version 1.3.6 which does not cause the issue described in https://jira.ez.no/browse/EZP-25533

Original PR: https://github.com/ezsystems/ezpublish-kernel/pull/1609
