### PR TITLE
Fix EZP-24705: whitespace between tags is removed on display.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -25,17 +25,13 @@
 {% endblock %}
 
 {% block ezxmltext_field %}
-{% spaceless %}
-    {% set field_value = field.value.xml|xmltext_to_html5 %}
+    {%- set field_value = field.value.xml|xmltext_to_html5 -%}
     {{ block( 'simple_block_field' ) }}
-{% endspaceless %}
 {% endblock %}
 
 {% block ezrichtext_field %}
-{% spaceless %}
-    {% set field_value = field.value.xml|richtext_to_html5 %}
+    {%- set field_value = field.value.xml|richtext_to_html5 -%}
     {{ block( 'simple_block_field' ) }}
-{% endspaceless %}
 {% endblock %}
 
 {% block ezauthor_field %}
@@ -447,7 +443,7 @@
 {% spaceless %}
     {% set field_value = field_value|default( field.value ) %}
     <div {{ block( 'field_attributes' ) }}>
-        {{ field_value|raw }}
+        {% endspaceless %}{{ field_value|raw }}{% spaceless %}
     </div>
 {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
## get orginal https://github.com/ezsystems/ezpublish-kernel/pull/1392

JIRA: https://jira.ez.no/browse/EZP-24705
Problem:

Whitespace between tags is removed when displaying xmltext content. For example:

<p><emphasize>em</emphasize> <strong>strong</strong></p>

is displayed instead as:

<p><emphasize>em</emphasize><strong>strong</strong></p>


The source of the problem seems to be twig's {% spaceless %}:

```
Use the spaceless tag to remove whitespace between HTML tags, not whitespace within HTML tags > or whitespace in plain text:
The behavior, however, is to also remove spaces between inner html tags.
```

Fix:

render the 'simple_block_field' outside of the spaceless tag, as well as it's field_value output.
