### PR TITLE
Fix EZP-25089: Clear persistence cache on object state assignment

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
@@ -275,6 +275,21 @@ class PersistenceCachePurger implements CacheClearerInterface
     }
 
     /**
+     * Clear object state assignment persistence cache by content id
+     *
+     * @param int $contentId
+     */
+    public function stateAssign( $contentId )
+    {
+        if ( $this->allCleared === true || $this->enabled === false )
+        {
+            return;
+        }
+
+        $this->cache->clear( 'objectstate', 'byContent', $contentId );
+    }
+
+    /**
      * Clear all user persistence cache
      *
      * @param int|null $id Purges all users cache if null

--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
@@ -224,6 +224,7 @@ class Configuration extends ContainerAware implements EventSubscriberInterface
         $ezpEvent->attach( 'content/section/cache', array( $this->persistenceCachePurger, 'section' ) );
         $ezpEvent->attach( 'user/cache/all', array( $this->persistenceCachePurger, 'user' ) );
         $ezpEvent->attach( 'content/translations/cache', array( $this->persistenceCachePurger, 'languages' ) );
+        $ezpEvent->attach( 'content/state/assign', array( $this->persistenceCachePurger, 'stateAssign' ) );
 
         // Register image alias removal listeners
         $ezpEvent->attach( 'image/removeAliases', array( $this->aliasCleaner, 'removeAliases' ) );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25089

Before this patch, you would end up in a scenario where an object state was changed from being not available to available but the front-end would crash with an error related to the old state.

Needs to be combined with ezsystems/ezpublish-legacy#1257

This is the same as https://github.com/ezsystems/LegacyBridge/pull/61
