### PR TITLE
Fix EZP-23518: Clearing image aliases with Symfony console with --purge

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
@@ -7,6 +7,5 @@ services:
         class: %ezpublish_legacy.image_alias.cleaner.class%
         arguments:
             - @ezpublish.image_alias.imagine.alias_cleaner
-            - @ezpublish.fieldType.ezimage.io_service
             - @ezpublish.core.io.image_fieldtype.legacy_url_redecorator
         lazy: true

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -239,9 +239,7 @@ class ImageStorage extends GatewayBasedStorage
 
             if ( $this->aliasCleaner )
             {
-                $this->aliasCleaner->removeAliases(
-                    $this->IOService->loadBinaryFileByUri( $storedFiles['original'] )
-                );
+                $this->aliasCleaner->removeAliases( $storedFiles['original'] );
             }
 
             foreach ( $storedFiles as $storedFilePath )

--- a/eZ/Publish/Core/MVC/Legacy/Image/AliasCleaner.php
+++ b/eZ/Publish/Core/MVC/Legacy/Image/AliasCleaner.php
@@ -10,7 +10,6 @@
 namespace eZ\Publish\Core\MVC\Legacy\Image;
 
 use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;
-use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
 
 class AliasCleaner implements AliasCleanerInterface
@@ -21,32 +20,23 @@ class AliasCleaner implements AliasCleanerInterface
     private $innerAliasCleaner;
 
     /**
-     * @var IOServiceInterface
-     */
-    private $ioService;
-
-    /**
      * @var UrlRedecoratorInterface
      */
     private $urlRedecorator;
 
     public function __construct(
         AliasCleanerInterface $innerAliasCleaner,
-        IOServiceInterface $ioService,
         UrlRedecoratorInterface $urlRedecorator
     )
     {
         $this->innerAliasCleaner = $innerAliasCleaner;
-        $this->ioService = $ioService;
         $this->urlRedecorator = $urlRedecorator;
     }
 
     public function removeAliases( $originalPath )
     {
         $this->innerAliasCleaner->removeAliases(
-            $this->ioService->loadBinaryFileByUri(
-                $this->urlRedecorator->redecorateFromTarget( $originalPath )
-            )
+            $this->urlRedecorator->redecorateFromTarget( $originalPath )
         );
     }
 }

--- a/eZ/Publish/Core/MVC/Legacy/Tests/Image/AliasCleanerTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Tests/Image/AliasCleanerTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * File containing the AliasCleanerTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\MVC\Legacy\Tests\Image;
+
+use eZ\Publish\Core\MVC\Legacy\Image\AliasCleaner;
+use PHPUnit_Framework_TestCase;
+
+class AliasCleanerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Legacy\Image\AliasCleaner
+     */
+    private $aliasCleaner;
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\Image\AliasCleanerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $innerAliasCleaner;
+
+    /**
+     * @var \eZ\Publish\Core\IO\UrlRedecoratorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $urlRedecorator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->innerAliasCleaner = $this->getMock( 'eZ\Publish\Core\FieldType\Image\AliasCleanerInterface' );
+        $this->urlRedecorator = $this->getMock( 'eZ\Publish\Core\IO\UrlRedecoratorInterface' );
+        $this->aliasCleaner = new AliasCleaner( $this->innerAliasCleaner, $this->urlRedecorator );
+    }
+
+    public function testRemoveAliases()
+    {
+        $originalPath = 'foo/bar/test.jpg';
+
+        $this->urlRedecorator
+            ->expects( $this->once() )
+            ->method( 'redecorateFromTarget' )
+            ->with( $originalPath );
+
+        $this->innerAliasCleaner
+            ->expects( $this->once() )
+            ->method( 'removeAliases' );
+
+        $this->aliasCleaner->removeAliases( $originalPath );
+    }
+}


### PR DESCRIPTION
...option results in PHP warnings.

Calling contentService->deleteContent on a contentInfo referring to a value object containing image fields fails, because eventually pathinfo is called on a BinaryFile object instead of an url.