### PR TITLE
Branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
         "process-timeout": 3000
     },
     "extra": {
-        "ezpublish-legacy-dir": "vendor/ezsystems/ezpublish-legacy"
+        "ezpublish-legacy-dir": "vendor/ezsystems/ezpublish-legacy",
+        "branch-alias": {
+            "dev-master": "14.12.x-dev"
+        }
     }
 }


### PR DESCRIPTION
With this branch alias it is possible to use the master branch without set an alias in the own composer.json