### PR TITLE
Fix legacy siteaccess mapper when URIs have UTF8 encoded chars

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/SiteAccess.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/SiteAccess.php
@@ -81,7 +81,7 @@ class SiteAccess extends ContainerAware implements EventSubscriberInterface
         }
 
         // uri_part
-        $pathinfo = rawurldecode( str_replace( $request->attributes->get( 'viewParametersString' ), '', $request->getPathInfo() ) );
+        $pathinfo = str_replace( $request->attributes->get( 'viewParametersString' ), '', rawurldecode( $request->getPathInfo() ) );
         $semanticPathinfo = $request->attributes->get( 'semanticPathinfo', $pathinfo );
         if ( $pathinfo != $semanticPathinfo )
         {

--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/SiteAccess.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/SiteAccess.php
@@ -81,7 +81,7 @@ class SiteAccess extends ContainerAware implements EventSubscriberInterface
         }
 
         // uri_part
-        $pathinfo = str_replace( $request->attributes->get( 'viewParametersString' ), '', $request->getPathInfo() );
+        $pathinfo = rawurldecode( str_replace( $request->attributes->get( 'viewParametersString' ), '', $request->getPathInfo() ) );
         $semanticPathinfo = $request->attributes->get( 'semanticPathinfo', $pathinfo );
         if ( $pathinfo != $semanticPathinfo )
         {

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/SiteAccess/LegacyMapperTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/SiteAccess/LegacyMapperTest.php
@@ -47,6 +47,38 @@ class LegacyMapperTest extends LegacyBasedTestCase
         self::assertSame( $expectedAccess, $bag->get( 'siteaccess' ) );
     }
 
+    /**
+     * @dataProvider siteAccessParamStringMatchProvider
+     */
+    public function testOnSiteAccessMatchUriPart($pathinfo, $semanticPathinfo, $viewParametersString, SiteAccess $siteaccess, $expectedAccess)
+    {
+        $container = $this->getContainerMock();
+        $container
+            ->expects($this->exactly(1))
+            ->method('get')
+            ->with('ezpublish.siteaccess')
+            ->will($this->returnValue($siteaccess));
+
+        $request = $this->getRequestMock();
+        $request
+            ->expects($this->any())
+            ->method('getPathInfo')
+            ->will($this->returnValue($pathinfo));
+        $request->attributes->set('semanticPathinfo', $semanticPathinfo);
+        $request->attributes->set('viewParametersString', $viewParametersString);
+
+        $mapper = new LegacyMapper();
+        $mapper->setContainer($container);
+        $bag = new \Symfony\Component\HttpFoundation\ParameterBag();
+        $mapper->onBuildKernelWebHandler(
+            new PreBuildKernelWebHandlerEvent(
+                $bag,
+                $request
+            )
+        );
+        self::assertSame($expectedAccess, $bag->get('siteaccess'));
+    }
+
     public function siteAccessMatchProvider()
     {
         return array(
@@ -199,6 +231,45 @@ class LegacyMapperTest extends LegacyBasedTestCase
                     'type'      => 10,
                     'uri_part'  => array()
                 )
+            ),
+        );
+    }
+
+    public function siteAccessParamStringMatchProvider()
+    {
+        return array(
+            array(
+                '/some/pathinfo/(param)/foo',
+                '/some/pathinfo',
+                '/(param)/foo',
+                new SiteAccess('foo', 'default'),
+                array(
+                    'name' => 'foo',
+                    'type' => 1,
+                    'uri_part' => array(),
+                ),
+            ),
+            array(
+                '/some/pathinfo/(param)/foo/b%C3%A4r',
+                '/some/pathinfo',
+                '/(param)/foo/bär',
+                new SiteAccess('foo', 'default'),
+                array(
+                    'name' => 'foo',
+                    'type' => 1,
+                    'uri_part' => array(),
+                ),
+            ),
+            array(
+                '/some/p%C3%A4thinfo/(param)/foo/b%C3%A4r',
+                '/some/päthinfo',
+                '/(param)/foo/bär',
+                new SiteAccess('foo', 'default'),
+                array(
+                    'name' => 'foo',
+                    'type' => 1,
+                    'uri_part' => array(),
+                ),
             ),
         );
     }


### PR DESCRIPTION
Due to fix on  [EZP-25171](https://github.com/ezsystems/ezpublish-kernel/commit/407e1a4cf1ca08f91b805e702bd9ff8c351a2c01), the full semanticPathinfo (including both base URI and viewParameters) is stored "rawurldecoded", but Pathinfo on $request remains untouched (urlencoded).
When comparing  encoded pathinfo with decoded semanticPathinfo, some bad parts are incorrectly added on siteaccess URI array.
Decoding 'pathinfo' before comparing to already decoded 'semanticPathinfo' solves the problem.