### PR TITLE
Removed @required doc tags

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
@@ -18,7 +18,7 @@ abstract class ContentCreateStruct extends ContentStruct
     /**
      * The content type for which the new content is created
      *
-     * @required
+     * Required.
      *
      * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
      */
@@ -60,7 +60,7 @@ abstract class ContentCreateStruct extends ContentStruct
      * be used for as initial language for the first created version.
      * It is also used as default language for added fields.
      *
-     * @required
+     * Required.
      *
      * @var string
      */

--- a/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
@@ -63,7 +63,7 @@ class LocationCreateStruct extends ValueObject
     /**
      * The id of the parent location under which the new location should be created.
      *
-     * @required
+     * Required.
      *
      * @var mixed
      */

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
@@ -22,7 +22,7 @@ abstract class ContentTypeCreateStruct extends ValueObject
     /**
      * String unique identifier of a type
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -31,7 +31,7 @@ abstract class ContentTypeCreateStruct extends ValueObject
     /**
      * Main language Code.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -94,7 +94,7 @@ abstract class ContentTypeCreateStruct extends ValueObject
     /**
      * An array of names with languageCode keys
      *
-     * @required - at least one name in the main language is required
+     * Required. - at least one name in the main language is required
      *
      * @var array an array of string
      */

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
@@ -19,7 +19,7 @@ class FieldDefinitionCreateStruct extends ValueObject
     /**
      * String identifier of the field type
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -30,7 +30,7 @@ class FieldDefinitionCreateStruct extends ValueObject
      *
      * Needs to be unique within the context of the Content Type this is added to.
      *
-     * @required
+     * Required.
      *
      * @var string
      */

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
@@ -20,7 +20,7 @@ class ObjectStateCreateStruct extends ValueObject
     /**
      * Readable unique string identifier of a group
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -36,7 +36,7 @@ class ObjectStateCreateStruct extends ValueObject
     /**
      * The default language code
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -45,7 +45,7 @@ class ObjectStateCreateStruct extends ValueObject
      /**
      * An array of names with languageCode keys
      *
-     * @required - at least one name in the main language is required
+     * Required. - at least one name in the main language is required
      *
      * @var string[]
      */

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
@@ -19,7 +19,7 @@ class ObjectStateGroupCreateStruct extends ValueObject
     /**
      * Readable unique string identifier of a group
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -28,7 +28,7 @@ class ObjectStateGroupCreateStruct extends ValueObject
     /**
      * The default language code
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -37,7 +37,7 @@ class ObjectStateGroupCreateStruct extends ValueObject
     /**
      * An array of names with languageCode keys
      *
-     * @required - at least one name in the main language is required
+     * Required. - at least one name in the main language is required
      *
      * @var string[]
      */

--- a/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
@@ -19,7 +19,7 @@ abstract class UserCreateStruct extends ContentCreateStruct
     /**
      * User login
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -28,7 +28,7 @@ abstract class UserCreateStruct extends ContentCreateStruct
     /**
      * User E-Mail address
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -37,7 +37,7 @@ abstract class UserCreateStruct extends ContentCreateStruct
     /**
      * The plain password
      *
-     * @required
+     * Required.
      *
      * @var string
      */

--- a/eZ/Publish/Core/FieldType/Image/Value.php
+++ b/eZ/Publish/Core/FieldType/Image/Value.php
@@ -28,7 +28,7 @@ class Value extends BaseValue
      * Image id
      *
      * @var mixed
-     * @required
+     * Required.
      */
     public $id;
 
@@ -43,7 +43,7 @@ class Value extends BaseValue
      * Display file name of the image
      *
      * @var string
-     * @required
+     * Required.
      */
     public $fileName;
 
@@ -51,7 +51,7 @@ class Value extends BaseValue
      * Size of the image file
      *
      * @var int
-     * @required
+     * Required.
      */
     public $fileSize;
 


### PR DESCRIPTION
This is a replay of the following commit:

https://github.com/ezsystems/ezpublish-kernel/commit/37e5858b29dbdb36f2704bfccfd6a8af664e3c9f?diff=unified

It fixes a bug where the following message appears:

> [Semantical Error] The annotation "@required" in property eZ\Publish\Core\FieldType\Image\Value::$id was never imported. Did you maybe forget to add a "use" statement for this annotation?